### PR TITLE
Automatic tag and release on master merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 10
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 10
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,11 @@ jobs:
           pip install -e ".[dev]"
       - name: Run tests
         run: tox -e tests
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Check version in changelog
         run: bash ./tag-from-pipeline.sh verify_changelog_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,7 @@ jobs:
       - name: Print current version
         run: |
           echo hello
-          t=$(git tag -l --sort=-version:refname | grep -E "^[0-9]+(\.[0-9]){1,2}$" | head -n 1)
-          echo $t
+          git tag
       - name: Run tests
         run: tox -e tests
       - name: Check version in changelog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-
     steps:
       - uses: actions/checkout@v2
         with:
@@ -23,10 +22,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
           sudo apt-get install graphviz
-      - name: Print current version
-        run: |
-          echo hello
-          git tag
       - name: Run tests
         run: tox -e tests
       - name: Check version in changelog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: read
-      contents: read
-      deployments: read
-      id-token: read
-      issues: read
-      discussions: read
-      packages: read
-      pull-requests: read
-      repository-projects: read
-      security-events: read
-      statuses: read
+
 
     steps:
       - uses: actions/checkout@v2
@@ -39,8 +27,8 @@ jobs:
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.PYPI_USER  }}
+          password: ${{ secrets.PYPI_PASSWORD }}
       - name: Check version in changelog
         run: bash ./tag-from-pipeline.sh verify_changelog_version
       - name: Test docs can be built

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -21,14 +23,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
           sudo apt-get install graphviz
+      - name: Print current version
+        run: |
+          echo hello
+          t=$(git tag -l --sort=-version:refname | grep -E "^[0-9]+(\.[0-9]){1,2}$" | head -n 1)
+          echo $t
       - name: Run tests
         run: tox -e tests
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.PYPI_USER  }}
-          password: ${{ secrets.PYPI_PASSWORD }}
       - name: Check version in changelog
         run: bash ./tag-from-pipeline.sh verify_changelog_version
       - name: Test docs can be built

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -24,7 +22,5 @@ jobs:
           sudo apt-get install graphviz
       - name: Run tests
         run: tox -e tests
-      - name: Check version in changelog
-        run: bash ./tag-from-pipeline.sh verify_changelog_version
       - name: Test docs can be built
         run: tox -e docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       checks: read
+      contents: read
+      deployments: read
+      id-token: read
+      issues: read
+      discussions: read
+      packages: read
+      pull-requests: read
+      repository-projects: read
+      security-events: read
+      statuses: read
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
           pip install -e ".[dev]"
       - name: Run tests
         run: tox -e tests
+      - name: Check version in changelog
+        run: bash ./tag-from-pipeline.sh verify_changelog_version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release to PyPI
+name: Upload to PyPI and publish documentation
 
 on:
   release:

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Create a new tag
-        run: echo test
+        run: echo Hello

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -1,7 +1,9 @@
 name: Create tag and release
 
 on:
-  pull_request:
+  push:
+    paths:
+      - 'CHANGELOG.rst'
 
 jobs:
   create_tag_and_release:
@@ -9,5 +11,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Create a new tag
-        run: echo Hello
+        with:
+          fetch-depth: 0
+      - name: Check version in changelog
+        run: bash ./tag-from-pipeline.sh verify_changelog_version
+      - name: Create new tag and release
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: bash ./tag-from-pipeline.sh create_new_tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -1,7 +1,7 @@
 name: Create tag and release
 
 on:
-  push:
+  pull_request:
     paths:
       - 'CHANGELOG.rst'
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 1.3
+===========
+
+* Add automatic tag and release on merge to master. `#7 <https://github.com/iqm-finland/iqm-client/pull/7>`_
+
 Version 1.4
 ===========
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 1.6
+===========
+
+* Implement automatic tagging and releasing. `#7 <https://github.com/iqm-finland/iqm-client/pull/7>`_
+
 Version 1.5
 ===========
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-Version 1.3
+Version 1.2
 ===========
 
 Features

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,6 @@
 Changelog
 =========
 
-Version 1.3
-===========
-
-* Add automatic tag and release on merge to master. `#7 <https://github.com/iqm-finland/iqm-client/pull/7>`_
-
 Version 1.5
 ===========
 

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -31,3 +31,17 @@ Run the tests:
 .. code-block:: bash
 
    $ tox
+
+
+Tagging and releasing
+---------------------
+
+After implementing changes to IQM client one usually wants to release a new version. This means
+that after the changes are merged to the main branch -
+ 1. the repository should have an updated CHANGELOG with information about the new changes,
+ 2. the latest commit should be tagged with the new version number,
+ 3. and a release should be created based on that tag.
+The last two steps are automated, so one needs to worry only about properly updating the CHANGELOG.
+It should be done along with the pull request which is introducing the main changes. Once the pull
+request is merged into main, a new tag and a release will be created automatically based on the latest
+version definition in the CHANGELOG.

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -42,6 +42,8 @@ that after the changes are merged to the main branch -
  2. the latest commit should be tagged with the new version number,
  3. and a release should be created based on that tag.
 The last two steps are automated, so one needs to worry only about properly updating the CHANGELOG.
-It should be done along with the pull request which is introducing the main changes. Once the pull
-request is merged into main, a new tag and a release will be created automatically based on the latest
-version definition in the CHANGELOG.
+It should be done along with the pull request which is introducing the main changes. The new version
+must be added on top of all existing versions and the title must be "Version MAJOR.MINOR", where MAJOR.MINOR
+represents the new version number. Please take a look at already existing versions and format the rest of
+your new CHANGELOG section similarly. Once the pull request is merged into main, a new tag and a release will
+be created automatically based on the latest version definition in the CHANGELOG.

--- a/tag-from-pipeline.sh
+++ b/tag-from-pipeline.sh
@@ -1,0 +1,51 @@
+#! /bin/bash
+
+function version_gt() {
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
+}
+
+function get_version_in_changelog() {
+  for i in 1 2 3 4 5 6 7
+  do
+    version_line=$(sed "${i}q;d" CHANGELOG.rst) # Get ith line of file
+    set -- $version_line
+    version=$2
+    if [[ $version =~ ^[0-9]+\.[0-9]+$ ]]; then
+      echo $version $3
+      return
+    fi
+  done
+  if [[ ! $version ]]
+  then
+    printf "\033[0;31mChangelog file is incorrect, one of the first seven lines should be of the format 'Version xx.xx.'\033[0m";
+    return 171
+  fi
+}
+
+function verify_changelog_version() {
+  read -r version date < <(get_version_in_changelog)
+  current_version=$(git tag -l --sort=-version:refname | grep -E "^[0-9]+(\.[0-9]){1,2}$" | head -n 1)
+  if version_gt "$current_version" "$version"; then
+    printf "\033[0;31mNew version in the changelog (%s) should be greater than the current version (%s).\n\033[0m" "$version" "$current_version";
+    return 172
+  fi
+  if [ $(git tag -l "$version") ]; then
+    printf "Version %s already exists.\n" "$version";
+  fi
+  printf "Current version is %s, new version is %s.\n" "$current_version" "$version";
+}
+
+function create_new_tag() {
+  read -r version date < <(get_version_in_changelog)
+  if [ -n "$date" ]; then
+    printf "\033[0;33mWarning: content found after the version number, not releasing a new version.\n\033[0m";
+    return 173
+  fi
+  # Only tag if version doesn't exist yet
+  if ! [ $(git tag -l "$version") ]; then
+    printf "Releasing version %s.\n" "$version"
+    # curl --request POST --header "PRIVATE-TOKEN: $PROJECT_TOKEN_PIPELINE" "https://gitlab.iqm.fi/api/v4/projects/${CI_PROJECT_ID}/repository/tags?tag_name=${version}&ref=master" -f
+  fi
+}
+
+"$@"

--- a/tag-from-pipeline.sh
+++ b/tag-from-pipeline.sh
@@ -44,7 +44,8 @@ function create_new_tag() {
   # Only tag if version doesn't exist yet
   if ! [ $(git tag -l "$version") ]; then
     printf "Releasing version %s.\n" "$version"
-    # curl --request POST --header "PRIVATE-TOKEN: $PROJECT_TOKEN_PIPELINE" "https://gitlab.iqm.fi/api/v4/projects/${CI_PROJECT_ID}/repository/tags?tag_name=${version}&ref=master" -f
+    curl -X POST -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_REPOSITORY/releases" \
+         -d "{\"tag_name\": \"$version\", \"name\": \"$version\", \"body\": \"Changelog: https://github.com/$GITHUB_REPOSITORY/blob/main/CHANGELOG.rst\"}"
   fi
 }
 


### PR DESCRIPTION
A github workflow to automatically tag and create a new release when when changelog is updated in a pull request.

1. on pull request (before and after merge) check that the new tag is valid and does not collide with another one.
2. on pull request (only after merge) create the new tag and the release.

COMP-212