### PR TITLE
Emit warnings in response as python UserWarning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 1.7
+===========
+
+* Emit warnings in server response as python UserWarning. `#15 <https://github.com/iqm-finland/iqm-client/pull/15>`_
+
 Version 1.6
 ===========
 

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -93,6 +93,7 @@ from __future__ import annotations
 import json
 import os
 import time
+import warnings
 from datetime import datetime
 from enum import Enum
 from posixpath import join
@@ -194,6 +195,8 @@ class RunResult(BaseModel):
     'if the run has finished successfully, the measurement results for the circuit'
     message: Optional[str] = Field(None, description='if the run failed, an error message')
     'if the run failed, an error message'
+    warnings: Optional[str] = Field(None, description='newline separated warning messages')
+    'newline separated warning messages'
 
     @staticmethod
     def from_dict(inp: dict[str, Union[str, dict]]) -> RunResult:
@@ -281,6 +284,8 @@ class IQMClient:
         result = requests.get(join(self._base_url, 'circuit/run/', str(run_id)), auth=self._credentials)
         result.raise_for_status()
         result = RunResult.from_dict(json.loads(result.text))
+        if result.warnings:
+            warnings.warn(result.warnings)
         if result.status == RunStatus.FAILED:
             raise CircuitExecutionError(result.message)
         return result

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -195,8 +195,8 @@ class RunResult(BaseModel):
     'if the run has finished successfully, the measurement results for the circuit'
     message: Optional[str] = Field(None, description='if the run failed, an error message')
     'if the run failed, an error message'
-    warnings: Optional[str] = Field(None, description='newline separated warning messages')
-    'newline separated warning messages'
+    warnings: Optional[list[str]] = Field(None, description='list of warning messages')
+    'list of warning messages'
 
     @staticmethod
     def from_dict(inp: dict[str, Union[str, dict]]) -> RunResult:
@@ -285,7 +285,8 @@ class IQMClient:
         result.raise_for_status()
         result = RunResult.from_dict(json.loads(result.text))
         if result.warnings:
-            warnings.warn(result.warnings)
+            for warning in result.warnings:
+                warnings.warn(warning)
         if result.status == RunStatus.FAILED:
             raise CircuitExecutionError(result.message)
         return result

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -129,7 +129,8 @@ def test_credentials_passed_to_server_from_env_variables(base_url, settings_dict
 
 def test_user_warning_is_emitted_when_warnings_in_response(base_url, settings_dict, capsys):
     client = IQMClient(base_url, settings_dict)
+    msg = 'This is a warning msg'
     with when(requests).get(f'{base_url}/circuit/run/{existing_run}', auth=None) \
-            .thenReturn(mock({'status_code': 200, 'text': json.dumps({'status': 'ready', 'warnings': 'A nice one'})})):
-        with pytest.warns(UserWarning, match='A nice one'):
+            .thenReturn(mock({'status_code': 200, 'text': json.dumps({'status': 'ready', 'warnings': [msg]})})):
+        with pytest.warns(UserWarning, match=msg):
             client.get_run(existing_run)

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -125,3 +125,11 @@ def test_credentials_passed_to_server_from_env_variables(base_url, settings_dict
     with when(requests).get(f'{base_url}/circuit/run/{existing_run}', auth=(fake_username, fake_api_key))\
             .thenReturn(mock({'status_code': 200, 'text': json.dumps({'status': 'pending'})})):
         client.get_run(existing_run)
+
+
+def test_user_warning_is_emitted_when_warnings_in_response(base_url, settings_dict, capsys):
+    client = IQMClient(base_url, settings_dict)
+    with when(requests).get(f'{base_url}/circuit/run/{existing_run}', auth=None) \
+            .thenReturn(mock({'status_code': 200, 'text': json.dumps({'status': 'ready', 'warnings': 'A nice one'})})):
+        with pytest.warns(UserWarning, match='A nice one'):
+            client.get_run(existing_run)


### PR DESCRIPTION
When the IQM server response contains warnings, those are emitted as python UserWarning