### PR TITLE
Added url validation for starting with http, https

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 1.9
+===========
+
+* Add IQMClient http, https server url validation `#20 <https://github.com/iqm-finland/iqm-client/pull/20>`_
+* Raise ClientConfigurationError Exception in-case of url valiation failure `#20 <https://github.com/iqm-finland/iqm-client/pull/20>`_
+
+
 Version 1.8
 ===========
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,9 +5,7 @@ Changelog
 Version 1.9
 ===========
 
-* Add IQMClient http, https server url validation `#20 <https://github.com/iqm-finland/iqm-client/pull/20>`_
-* Raise ClientConfigurationError Exception in-case of url valiation failure `#20 <https://github.com/iqm-finland/iqm-client/pull/20>`_
-
+* Validate that the schema of IQM server URL is http or https. `#20 <https://github.com/iqm-finland/iqm-client/pull/20>`_
 
 Version 1.8
 ===========

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -251,7 +251,7 @@ class IQMClient:
             api_key: Optional[str] = None
     ):
         if not url.startswith(('http:', 'https:')):
-            raise ClientConfigurationError(f"The URL schema has to be http or https. Incorrect schema in URL: {url}")
+            raise ClientConfigurationError(f'The URL schema has to be http or https. Incorrect schema in URL: {url}')
         self._base_url = url
         self._settings = settings
         self._credentials = _get_credentials(username, api_key)

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -250,7 +250,7 @@ class IQMClient:
             username: Optional[str] = None,
             api_key: Optional[str] = None
     ):
-        if not url.startswith(("http:", "https:")):
+        if not url.startswith(('http:', 'https:')):
             raise ClientConfigurationError(f"The URL schema has to be http or https. Incorrect schema in URL: {url}")
         self._base_url = url
         self._settings = settings

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -108,6 +108,11 @@ DEFAULT_TIMEOUT_SECONDS = 900
 SECONDS_BETWEEN_CALLS = 1
 
 
+class ClientConfigurationError(RuntimeError):
+    """Wrong configuration provided.
+    """
+
+
 class CircuitExecutionError(RuntimeError):
     """Something went wrong on the server.
     """
@@ -245,6 +250,8 @@ class IQMClient:
             username: Optional[str] = None,
             api_key: Optional[str] = None
     ):
+        if not url.startswith(("http","https")):
+            raise ClientConfigurationError(f"Wrong url provided: {url}")
         self._base_url = url
         self._settings = settings
         self._credentials = _get_credentials(username, api_key)

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -250,8 +250,8 @@ class IQMClient:
             username: Optional[str] = None,
             api_key: Optional[str] = None
     ):
-        if not url.startswith(("http","https")):
-            raise ClientConfigurationError(f"Wrong url provided: {url}")
+        if not url.startswith(("http:", "https:")):
+            raise ClientConfigurationError(f"The URL schema has to be http or https. Incorrect schema in URL: {url}")
         self._base_url = url
         self._settings = settings
         self._credentials = _get_credentials(username, api_key)

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -136,13 +136,6 @@ def test_user_warning_is_emitted_when_warnings_in_response(base_url, settings_di
             client.get_run(existing_run)
 
 
-def test_base_url_is_valid(base_url, settings_dict):
-    try:
-        client = IQMClient(base_url, settings_dict)
-    except Exception as exc:
-        assert False, f" IQMClient raised an exception {exc}"
-
-
 def test_base_url_is_invalid(settings_dict):
     invalid_base_url = 'https//example.com'
     with pytest.raises(ClientConfigurationError) as exc:

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -21,8 +21,8 @@ import requests
 from mockito import mock, when
 from requests import HTTPError
 
-from iqm_client.iqm_client import (Circuit, IQMClient, RunStatus,
-                                   SingleQubitMapping, ClientConfigurationError)
+from iqm_client.iqm_client import (Circuit, ClientConfigurationError,
+                                   IQMClient, RunStatus, SingleQubitMapping)
 from tests.conftest import existing_run, missing_run
 
 

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -139,5 +139,5 @@ def test_user_warning_is_emitted_when_warnings_in_response(base_url, settings_di
 def test_base_url_is_invalid(settings_dict):
     invalid_base_url = 'https//example.com'
     with pytest.raises(ClientConfigurationError) as exc:
-        client = IQMClient(invalid_base_url, settings_dict)
-    assert f"The URL schema has to be http or https. Incorrect schema in URL: {invalid_base_url}" == str(exc.value)
+        IQMClient(invalid_base_url, settings_dict)
+    assert f'The URL schema has to be http or https. Incorrect schema in URL: {invalid_base_url}' == str(exc.value)

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -148,3 +148,4 @@ def test_base_url_is_invalid(settings_dict):
     with pytest.raises(ClientConfigurationError) as exc:
         client = IQMClient(invalid_base_url, settings_dict)
     assert f"The URL schema has to be http or https. Incorrect schema in URL: {invalid_base_url}" == str(exc.value)
+    

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -22,7 +22,7 @@ from mockito import mock, when
 from requests import HTTPError
 
 from iqm_client.iqm_client import (Circuit, IQMClient, RunStatus,
-                                   SingleQubitMapping)
+                                   SingleQubitMapping, ClientConfigurationError)
 from tests.conftest import existing_run, missing_run
 
 
@@ -134,3 +134,17 @@ def test_user_warning_is_emitted_when_warnings_in_response(base_url, settings_di
             .thenReturn(mock({'status_code': 200, 'text': json.dumps({'status': 'ready', 'warnings': [msg]})})):
         with pytest.warns(UserWarning, match=msg):
             client.get_run(existing_run)
+
+
+def test_base_url_is_valid(base_url, settings_dict):
+    try:
+        client = IQMClient(base_url, settings_dict)
+    except Exception as exc:
+        assert False, f" IQMClient raised an exception {exc}"
+
+
+def test_base_url_is_invalid(settings_dict):
+    invalid_base_url = 'https//example.com'
+    with pytest.raises(ClientConfigurationError) as exc:
+        client = IQMClient(invalid_base_url, settings_dict)
+    assert f"The URL schema has to be http or https. Incorrect schema in URL: {invalid_base_url}" == str(exc.value)

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -141,4 +141,3 @@ def test_base_url_is_invalid(settings_dict):
     with pytest.raises(ClientConfigurationError) as exc:
         client = IQMClient(invalid_base_url, settings_dict)
     assert f"The URL schema has to be http or https. Incorrect schema in URL: {invalid_base_url}" == str(exc.value)
-    


### PR DESCRIPTION
The validation (starting with http, https) is expected by the docstring but not enforced.
It might be helpful to fail early and fast since there might be some prior resource intensive steps before utilising the IQM client.