### PR TITLE
Make qubit_mapping an optional parameter in submit_circuit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 1.10
 ============
 
-* Make qubit_mapping an optional parameter in submit_circuit. `#21 <https://github.com/iqm-finland/iqm-client/pull/21>`
+* Make ``qubit_mapping`` an optional parameter in ``IQMClient.submit_circuit``. `#21 <https://github.com/iqm-finland/iqm-client/pull/21>`_
 
 Version 1.9
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 1.10
+============
+
+* Make qubit_mapping an optional parameter in submit_circuit. `#21 <https://github.com/iqm-finland/iqm-client/pull/21>`
+
 Version 1.9
 ===========
 

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -266,8 +266,8 @@ class IQMClient:
 
         Args:
             circuit: circuit to be executed
-            qubit_mapping: mapping of human-readable qubit names in ``circuit`` to physical qubit names,
-                           if circuit uses physical qubit names qubit_mapping can be set to None (default)
+            qubit_mapping: Mapping of human-readable (logical) qubit names in ``circuit`` to physical qubit names.
+                Can be set to ``None`` if ``circuit`` already uses physical qubit names.
             shots: number of times ``circuit`` is executed
 
         Returns:

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -176,10 +176,7 @@ class RunRequest(BaseModel):
     'quantum circuit to execute'
     settings: dict[str, Any] = Field(..., description='EXA settings node containing the calibration data')
     'EXA settings node containing the calibration data'
-    qubit_mapping: list[SingleQubitMapping] = Field(
-        ...,
-        description='mapping of logical qubit names to physical qubit names'
-    )
+    qubit_mapping: Optional[list[SingleQubitMapping]]
     'mapping of logical qubit names to physical qubit names'
     shots: int = Field(..., description='how many times to execute the circuit')
     'how many times to execute the circuit'
@@ -259,14 +256,15 @@ class IQMClient:
     def submit_circuit(
             self,
             circuit: Circuit,
-            qubit_mapping: list[SingleQubitMapping],
+            qubit_mapping: Optional[list[SingleQubitMapping]] = None,
             shots: int = 1
     ) -> UUID:
         """Submits a quantum circuit to be executed on a quantum computer.
 
         Args:
             circuit: circuit to be executed
-            qubit_mapping: mapping of human-readable qubit names in ``circuit`` to physical qubit names
+            qubit_mapping: mapping of human-readable qubit names in ``circuit`` to physical qubit names,
+                           if circuit uses physical qubit names qubit_mapping can be set to None (default)
             shots: number of times ``circuit`` is executed
 
         Returns:

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -176,7 +176,10 @@ class RunRequest(BaseModel):
     'quantum circuit to execute'
     settings: dict[str, Any] = Field(..., description='EXA settings node containing the calibration data')
     'EXA settings node containing the calibration data'
-    qubit_mapping: Optional[list[SingleQubitMapping]]
+    qubit_mapping: Optional[list[SingleQubitMapping]] = Field(
+        None,
+        description='mapping of logical qubit names to physical qubit names'
+    )
     'mapping of logical qubit names to physical qubit names'
     shots: int = Field(..., description='how many times to execute the circuit')
     'how many times to execute the circuit'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,47 @@ def settings_dict():
         return json.loads(f.read())
 
 
+@pytest.fixture
+def sample_circuit():
+    """
+    A sample circuit for testing submit_circuit.
+    """
+    return {
+        'name': 'The circuit',
+        'instructions': [
+            {
+                'name': 'cz',
+                'qubits': [
+                    'Qubit A',
+                    'Qubit B'
+                ],
+                'args': {}
+            },
+            {
+                'name': 'phased_rx',
+                'qubits': [
+                    'Qubit A'
+                ],
+                'args': {
+                    'phase_t': 1.22,
+                    'angle_t': {
+                        'expr': '{{alpha}}/2'
+                    }
+                }
+            },
+            {
+                'name': 'measurement',
+                'qubits': [
+                    'Qubit A'
+                ],
+                'args': {
+                    'output_label': 'A'
+                }
+            }
+        ]
+    }
+
+
 def generate_server_stubs(base_url):
     """
     Mocking some of the calls to the server by mocking 'requests'

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -26,7 +26,7 @@ from iqm_client.iqm_client import (Circuit, ClientConfigurationError,
 from tests.conftest import existing_run, missing_run
 
 
-def test_submit_circuit_returns_id(mock_server, settings_dict, base_url):
+def test_submit_circuit_returns_id(mock_server, settings_dict, base_url, sample_circuit):
     """
     Tests sending a circuit
     """
@@ -36,41 +36,18 @@ def test_submit_circuit_returns_id(mock_server, settings_dict, base_url):
             SingleQubitMapping(logical_name='Qubit A', physical_name='qubit_1'),
             SingleQubitMapping(logical_name='Qubit B', physical_name='qubit_2')
         ],
-        circuit=Circuit.parse_obj(
-            {
-                'name': 'The circuit',
-                'instructions': [
-                    {
-                        'name': 'cz',
-                        'qubits': [
-                            'Qubit A',
-                            'Qubit B'
-                        ],
-                        'args': {}
-                    },
-                    {
-                        'name': 'phased_rx',
-                        'qubits': [
-                            'Qubit A'
-                        ],
-                        'args': {
-                            'phase_t': 1.22,
-                            'angle_t': {
-                                'expr': '{{alpha}}/2'
-                            }
-                        }
-                    },
-                    {
-                        'name': 'measurement',
-                        'qubits': [
-                            'Qubit A'
-                        ],
-                        'args': {
-                            'output_label': 'A'
-                        }
-                    }
-                ]
-            }),
+        circuit=Circuit.parse_obj(sample_circuit),
+        shots=1000)
+    assert run_id == existing_run
+
+
+def test_submit_circuit_without_qubit_mapping_returns_id(mock_server, settings_dict, base_url, sample_circuit):
+    """
+    Tests sending a circuit without qubit mapping
+    """
+    client = IQMClient(base_url, settings_dict)
+    run_id = client.submit_circuit(
+        circuit=Circuit.parse_obj(sample_circuit),
         shots=1000)
     assert run_id == existing_run
 


### PR DESCRIPTION
If submitted circuit uses physical qubit names directly there is no need for name mapping and qubit_mapping can be omitted.