### PR TITLE
Fix incorrect description in documentation

### DIFF
--- a/docs/json_schemas.rst
+++ b/docs/json_schemas.rst
@@ -1,7 +1,7 @@
 JSON schemas
 ============
 
-The following JSON schemas describe the payload format of the ``iqm-client`` HTTP API.
+The following JSON schemas describe the format of the payloads ``iqm-client`` sends to the IQM server.
 
 .. |link-pre| raw:: html
 


### PR DESCRIPTION
IQM client has no HTTP API. The schema shows what IQM client sends to the server HTTP interface.