### PR TITLE
Add function to check job status

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 * Hayk Sargsyan <hayk@meetiqm.com>
 * Maxim Smirnov <dc914337@gmail.com>
 * Olli Tyrkkö <otyrkko@meetiqm.com>
+* Rakhim Davletkaliyev <rakhim.davletkaliyev@meetiqm.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,16 @@
 Changelog
 =========
 
+Version 3.1
+===========
+
+* Add function `get_run_status` to check status of execution without getting measurement results. `#29 <https://github.com/iqm-finland/iqm-client/pull/29>`_
+
 Version 3.0
 ===========
 
 * Update HTTP endpoints for circuit execution and results retrieval. `#26 <https://github.com/iqm-finland/iqm-client/pull/26>`_
 * Requires CoCoS 4.0
-
 
 Version 2.2
 ===========

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -435,8 +435,6 @@ class IQMClient:
         if result.warnings:
             for warning in result.warnings:
                 warnings.warn(warning)
-        if result.status == RunStatus.FAILED:
-            raise CircuitExecutionError(result.message)
         return result
 
     def wait_for_results(self, job_id: UUID, timeout_secs: float = DEFAULT_TIMEOUT_SECONDS) -> RunResult:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,11 +144,18 @@ def generate_server_stubs(base_url):
         )
     )
 
+    when(requests).get(f'{base_url}/jobs/{existing_run}/status', ...).thenReturn(
+        MockJsonResponse(200, {'status': 'pending'})
+    ).thenReturn(
+        MockJsonResponse(200, {'status': 'ready'})
+    )
+
     # 'run was not created' response
     no_run_response = Response()
     no_run_response.status_code = 404
     no_run_response.reason = 'Run not found'
     when(requests).get(f'{base_url}/jobs/{missing_run}', ...).thenReturn(no_run_response)
+    when(requests).get(f'{base_url}/jobs/{missing_run}/status', ...).thenReturn(no_run_response)
 
 
 def prepare_tokens(

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -50,13 +50,35 @@ def test_submit_circuit_without_qubit_mapping_returns_id(mock_server, settings_d
     assert job_id == existing_run
 
 
-def test_get_run_status_for_existing_run(mock_server, base_url, settings_dict):
+def test_get_run_status_and_results_for_existing_run(mock_server, base_url, settings_dict):
     """
     Tests getting the run status
     """
     client = IQMClient(base_url, settings_dict)
     assert client.get_run(existing_run).status == RunStatus.PENDING
-    assert client.get_run(existing_run).status == RunStatus.READY
+    ready_run = client.get_run(existing_run)
+    assert ready_run.status == RunStatus.READY
+    assert ready_run.measurements is not None
+
+
+def test_get_run_status_for_existing_run(mock_server, base_url, settings_dict):
+    """
+    Tests getting the run status
+    """
+    client = IQMClient(base_url, settings_dict)
+    assert client.get_run_status(existing_run).status == RunStatus.PENDING
+    ready_run = client.get_run_status(existing_run)
+    assert ready_run.status == RunStatus.READY
+    assert ready_run.measurements is None
+
+
+def test_get_run_status_and_results_for_missing_run(mock_server, base_url, settings_dict):
+    """
+    Tests getting a task that was not created
+    """
+    client = IQMClient(base_url, settings_dict)
+    with pytest.raises(HTTPError):
+        assert client.get_run(missing_run)
 
 
 def test_get_run_status_for_missing_run(mock_server, base_url, settings_dict):
@@ -65,7 +87,7 @@ def test_get_run_status_for_missing_run(mock_server, base_url, settings_dict):
     """
     client = IQMClient(base_url, settings_dict)
     with pytest.raises(HTTPError):
-        assert client.get_run(missing_run)
+        assert client.get_run_status(missing_run)
 
 
 def test_waiting_for_results(mock_server, base_url, settings_dict):


### PR DESCRIPTION
A new feature of IQM server allows to check the status of a job at a new endpoint `/jobs/$jobId/status`. Unlike previously existing endpoint `/jobs/$jobId`, the new endpoint will not return measurement results in case the job is finished.  