### PR TITLE
Checkout full history when building docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,9 +52,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
           sudo apt-get install graphviz
-      - name: Checkout latest tagged commit
-        run: |
-          git checkout $(git describe --tags --abbrev=0)
       - name: Build docs
         run: |
           tox -e docs


### PR DESCRIPTION
Change github actions so that full git history (including tags) is checked out when building docs. This is needed for multiversion docs, which are built separately for each git tag.