### PR TITLE
Update args structure for phased rx test case

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,10 +100,8 @@ def sample_circuit():
                     'Qubit A'
                 ],
                 'args': {
-                    'phase_t': 1.22,
-                    'angle_t': {
-                        'expr': '{{alpha}}/2'
-                    }
+                    'phase_t': 0.7,
+                    'angle_t': 0.25
                 }
             },
             {


### PR DESCRIPTION
The structure for the test case does not reflect the documentation at the moment. This pull request changes it, so it uses the same structure as the demo.