### PR TITLE
Add optional calibration_set_id to the request sent to IQM Server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,6 @@ Version 5.1
 ===========
 
 * Add optional ``calibration_set_id`` parameter to ``IQMClient.submit_circuit``.
-* Requires CoCoS 10.2
 
 Version 5.0
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 5.1
+===========
+
+* Add optional ``calibration_set_id`` parameter to ``IQMClient.submit_circuit``.
+* Requires CoCoS 10.2
+
 Version 5.0
 ===========
 

--- a/docs/generate_json_schemas.py
+++ b/docs/generate_json_schemas.py
@@ -30,6 +30,7 @@ SCHEMAS = {
     'run_request_schema': RunRequest,
 }
 
+
 def generate_json_schema(cls: type[BaseModel], filename: str) -> dict[str, Any]:
     """Generate a JSON schema dictionary from the given Pydantic model.
 
@@ -47,6 +48,7 @@ def generate_json_schema(cls: type[BaseModel], filename: str) -> dict[str, Any]:
         **json_schema,
     }
 
+
 def save_json_schemas_to_docs() -> None:
     """Save the JSON schemas in the docs folder.
     """
@@ -55,6 +57,7 @@ def save_json_schemas_to_docs() -> None:
         json_schema_path = os.path.join(os.getcwd(), 'docs', filename)
         with open(json_schema_path, 'w', encoding='utf-8') as f:
             f.write(json.dumps(generate_json_schema(cls, filename), indent=2))
+
 
 if __name__ == '__main__':
     save_json_schemas_to_docs()

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -222,14 +222,14 @@ class RunRequest(BaseModel):
     'batch of quantum circuit(s) to execute'
     settings: Optional[dict[str, Any]] = Field(
         None,
-        description='EXA settings node containing the calibration data, or None if using default settings'
+        description='EXA settings node containing the calibration data, or None to use the latest calibration set'
     )
-    'EXA settings node containing the calibration data, or None if using default settings'
+    'EXA settings node containing the calibration data, or None to use the latest calibration set'
     calibration_set_id: Optional[int] = Field(
         None,
-        description='which calibration set to use for execution'
+        description='ID of the calibration set to use, or None to use the latest calibration set'
     )
-    'which calibration set to use for execution'
+    'ID of the calibration set to use, or None to use the latest calibration set'
     qubit_mapping: Optional[list[SingleQubitMapping]] = Field(
         None,
         description='mapping of logical qubit names to physical qubit names, or None if using physical qubit names'
@@ -506,8 +506,8 @@ class IQMClient:
             qubit_mapping: Mapping of human-readable (logical) qubit names in to physical qubit names.
                 Can be set to ``None`` if all ``circuits`` already use physical qubit names.
                 Note that the ``qubit_mapping`` is used for all ``circuits``.
-            settings: Settings for the quantum computer.
-            calibration_set_id: ID of the calibration set to be used instead of settings.
+            settings: settings for the quantum computer
+            calibration_set_id: ID of the calibration set to use instead of ``settings``
             shots: number of times ``circuit`` is executed
 
         Returns:

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -225,6 +225,11 @@ class RunRequest(BaseModel):
         description='EXA settings node containing the calibration data, or None if using default settings'
     )
     'EXA settings node containing the calibration data, or None if using default settings'
+    calibration_set_id: Optional[int] = Field(
+        None,
+        description='which calibration set to use for execution'
+    )
+    'which calibration set to use for execution'
     qubit_mapping: Optional[list[SingleQubitMapping]] = Field(
         None,
         description='mapping of logical qubit names to physical qubit names, or None if using physical qubit names'
@@ -491,6 +496,7 @@ class IQMClient:
             *,
             qubit_mapping: Optional[dict[str, str]] = None,
             settings: Optional[dict[str, Any]] = None,
+            calibration_set_id: Optional[int] = None,
             shots: int = 1,
     ) -> UUID:
         """Submits a batch of quantum circuits for execution on a quantum computer.
@@ -501,6 +507,7 @@ class IQMClient:
                 Can be set to ``None`` if all ``circuits`` already use physical qubit names.
                 Note that the ``qubit_mapping`` is used for all ``circuits``.
             settings: Settings for the quantum computer.
+            calibration_set_id: ID of the calibration set to be used instead of settings.
             shots: number of times ``circuit`` is executed
 
         Returns:
@@ -534,6 +541,7 @@ class IQMClient:
             qubit_mapping=qubit_mapping,
             circuits=circuits,
             settings=settings,
+            calibration_set_id=calibration_set_id,
             shots=shots
         )
 

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -222,9 +222,9 @@ class RunRequest(BaseModel):
     'batch of quantum circuit(s) to execute'
     settings: Optional[dict[str, Any]] = Field(
         None,
-        description='EXA settings node containing the calibration data, or None to use the latest calibration set'
+        description='IQM hardware settings and calibration data, or None to use the latest calibration set'
     )
-    'EXA settings node containing the calibration data, or None to use the latest calibration set'
+    'IQM hardware settings and calibration data, or None to use the latest calibration set'
     calibration_set_id: Optional[int] = Field(
         None,
         description='ID of the calibration set to use, or None to use the latest calibration set'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,11 @@ def settings_dict():
         return json.loads(f.read())
 
 
+@pytest.fixture()
+def calibration_set_id():
+    return 24
+
+
 @pytest.fixture
 def tokens_dict():
     """
@@ -76,6 +81,7 @@ def tokens_dict():
     tokens_path = os.path.dirname(os.path.realpath(__file__)) + '/resources/tokens.json'
     with open(tokens_path, 'r', encoding='utf-8') as f:
         return json.loads(f.read())
+
 
 @pytest.fixture
 def sample_circuit():

--- a/tests/test_generate_run_request_json_schema.py
+++ b/tests/test_generate_run_request_json_schema.py
@@ -31,6 +31,7 @@ def sample_valid_run_request(sample_circuit):
     return RunRequest(
         circuits=[sample_circuit],
         settings={},
+        calibration_set_id=24,
         shots=1000,
         qubit_mapping=[{'logical_name': 'q1', 'physical_name': 'qubit_1'}]
     ).dict()

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -85,12 +85,25 @@ def test_submit_circuit_with_incomplete_qubit_mapping(mock_server, settings_dict
 
 def test_submit_circuits_without_settings_returns_id(mock_server, base_url, sample_circuit):
     """
-    Tests sending a circuit
+    Tests sending a circuit without settings
     """
     client = IQMClient(base_url)
     job_id = client.submit_circuits(
         qubit_mapping={'Qubit A': 'QB1', 'Qubit B': 'QB2'},
         circuits=[Circuit.parse_obj(sample_circuit)],
+        shots=1000)
+    assert job_id == existing_run
+
+
+def test_submit_circuits_with_calibration_set_id_returns_id(mock_server, base_url, calibration_set_id, sample_circuit):
+    """
+    Tests sending a circuit with calibration set id
+    """
+    client = IQMClient(base_url)
+    job_id = client.submit_circuits(
+        qubit_mapping={'Qubit A': 'QB1', 'Qubit B': 'QB2'},
+        circuits=[Circuit.parse_obj(sample_circuit)],
+        calibration_set_id=calibration_set_id,
         shots=1000)
     assert job_id == existing_run
 


### PR DESCRIPTION
Allow users to provide a `calibration_set_id`. Calibration data will be retrieved from the observations database by IQM Server. If `calibration_set_id` is provided, `settings` should not be provided, and vice versa (IQM Server, namely CoCoS, will reject any requests containing both fields simultaneously).