### PR TITLE
OpenTelemetry support

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,3 +2,6 @@
 
 [mypy-mockito.*]
 ignore_missing_imports = True
+
+[mypy-opentelemetry.*]
+ignore_missing_imports = True

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 9.3
+===========
+
+* Support OpenTelemetry trace propagation. `#59 <https://github.com/iqm-finland/iqm-client/pull/59>`_
+
 Version 9.2
 ===========
 

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -611,6 +611,17 @@ class IQMClient:
         if bearer_token:
             headers['Authorization'] = bearer_token
 
+        try:
+            # check if someone is trying to profile us with OpenTelemetry
+            # pylint: disable=import-outside-toplevel
+            # pylint: disable=import-error
+            from opentelemetry import propagate
+
+            propagate.inject(headers)
+        except ImportError as _:
+            # no OpenTelemetry, no problem
+            pass
+
         result = requests.post(
             join(self._base_url, 'jobs'), json=data.dict(exclude_none=True), headers=headers, timeout=REQUESTS_TIMEOUT
         )


### PR DESCRIPTION
The idea is IQM Client does not depend on OpenTelemetry, but if there is an active context (e.g. someone is profiling circuits execution time), it will add necessary headers to the backend request. Mostly used internally by IQM.