### PR TITLE
Keep retrying connecting to the IQM Server on 502 error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 9.5
+===========
+
+* Retry requests to the IQM Server if the server is busy. `#61 <https://github.com/iqm-finland/iqm-client/pull/61>`_
+
 Version 9.4
 ===========
 

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -554,10 +554,9 @@ class IQMClient:
             pass
 
     def _retry_request_on_error(self, request: Callable[[], requests.Response]) -> requests.Response:
-        """This is a workaround for 502 errors.
-        Currnet implementation of the server side CoCoS can run out of network connections
-        and silently drop incoming connections making IQM Client to fail with 502 errors.
-        This is a temporary workaround to retry the request in case of 502 errors."""
+        """This is a temporary workaround for 502 errors.
+        The current implementation of the server side can run out of network connections
+        and silently drop incoming connections making IQM Client to fail with 502 errors."""
 
         while True:
             result = request()


### PR DESCRIPTION
IQM Server might be busy and unable to accept new connections. This is a temporary workaround until the server is actually fixed.