### PR TITLE
Make IQM Server requests interval configurable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 9.6
+===========
+
+* Reduce wait interval between requests to the IQM Server and make it configurable with the ``IQM_CLIENT_SECONDS_BETWEEN_CALLS`` environment var. `#62 <https://github.com/iqm-finland/iqm-client/pull/66>`_
+
 Version 9.5
 ===========
 

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -716,7 +716,8 @@ class IQMClient:
     def wait_for_results(self, job_id: UUID, timeout_secs: float = DEFAULT_TIMEOUT_SECONDS) -> RunResult:
         """Poll results until a job is either ready, failed, or timed out.
            Note, that jobs handling on the server side is async and if we try to request the results
-           right after submitting the job (which is usually the case) we will find the job is still pending at least for the first query.
+           right after submitting the job (which is usually the case)
+           we will find the job is still pending at least for the first query.
 
         Args:
             job_id: id of the job to wait for

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -716,7 +716,7 @@ class IQMClient:
     def wait_for_results(self, job_id: UUID, timeout_secs: float = DEFAULT_TIMEOUT_SECONDS) -> RunResult:
         """Poll results until a job is either ready, failed, or timed out.
            Note, that jobs handling on the server side is async and if we try to request the results
-           right after submitting the job (which is usually the case) we will always once get a still pending job.
+           right after submitting the job (which is usually the case) we will find the job is still pending at least for the first query.
 
         Args:
             job_id: id of the job to wait for

--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -138,7 +138,7 @@ import requests
 REQUESTS_TIMEOUT = 60
 
 DEFAULT_TIMEOUT_SECONDS = 900
-SECONDS_BETWEEN_CALLS = 3
+SECONDS_BETWEEN_CALLS = float(os.environ.get('IQM_CLIENT_SECONDS_BETWEEN_CALLS', 1.0))
 REFRESH_MARGIN_SECONDS = REQUESTS_TIMEOUT
 
 AUTH_CLIENT_ID = 'iqm_client'
@@ -715,6 +715,8 @@ class IQMClient:
 
     def wait_for_results(self, job_id: UUID, timeout_secs: float = DEFAULT_TIMEOUT_SECONDS) -> RunResult:
         """Poll results until a job is either ready, failed, or timed out.
+           Note, that jobs handling on the server side is async and if we try to request the results
+           right after submitting the job (which is usually the case) we will always once get a still pending job.
 
         Args:
             job_id: id of the job to wait for


### PR DESCRIPTION
And reduce default value to 1 sec (as error 502 has another workaround for now).