### PR TITLE
Check if auth is missing on quantum architecture fetch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 10.1
+============
+
+* Rais an error while fetching quantum architecture if authentication is not provided. `#66 <https://github.com/iqm-finland/iqm-client/pull/66>`_
+
 Version 10.0
 ============
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 10.1
 ============
 
-* Rais an error while fetching quantum architecture if authentication is not provided. `#66 <https://github.com/iqm-finland/iqm-client/pull/66>`_
+* Raise an error while fetching quantum architecture if authentication is not provided. `#66 <https://github.com/iqm-finland/iqm-client/pull/66>`_
 
 Version 10.0
 ============

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,7 +252,9 @@ def expect_status_request(url: str, access_token: Optional[str], times: int = 1)
     return job_id
 
 
-def expect_submit_circuits_request(url: str, access_token: Optional[str], times: int = 1, response_status: int = 200):
+def expect_submit_circuits_request(
+    url: str, access_token: Optional[str], times: int = 1, response_status: int = 200
+) -> UUID:
     """Prepare for submit_circuits request.
 
     Args:
@@ -262,10 +264,12 @@ def expect_submit_circuits_request(url: str, access_token: Optional[str], times:
         times: number of times the status request is expected to be made
         response_status: status code to return in the response
     """
+    job_id = uuid4()
     headers = None if access_token is None else {'Authorization': f'Bearer {access_token}', 'Expect': '100-Continue'}
     expect(requests, times=times).post(
         f'{url}/jobs', json=ANY(dict), headers=headers, timeout=REQUESTS_TIMEOUT
-    ).thenReturn(MockJsonResponse(response_status, {'id': str(uuid4())}))
+    ).thenReturn(MockJsonResponse(response_status, {'id': str(job_id)}))
+    return job_id
 
 
 def expect_logout(auth_server_url: str, refresh_token: str):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -92,7 +92,7 @@ def test_add_authorization_header_on_submit_circuits_when_credentials_are_provid
     base_url, credentials, sample_circuit
 ):
     """
-    Tests that `submit_circuits` requests are sent with Authorization header when credentials are provided
+    Tests that ``submit_circuits`` requests are sent with Authorization header when credentials are provided
     """
     tokens = prepare_tokens(300, 3600, **credentials)
     expected_job_id = expect_submit_circuits_request(base_url, tokens['access_token'], response_status=200)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -78,7 +78,7 @@ def test_get_initial_tokens_with_incomplete_credentials_from_env_variables(base_
 
 def test_add_authorization_header_when_credentials_are_provided(base_url, credentials):
     """
-    Tests that requests are sent with Authorization header when credentials are provided
+    Tests that `get_run` requests are sent with Authorization header when credentials are provided
     """
     tokens = prepare_tokens(300, 3600, **credentials)
     job_id = expect_status_request(base_url, tokens['access_token'])
@@ -92,35 +92,23 @@ def test_add_authorization_header_on_submit_circuits_when_credentials_are_provid
     base_url, credentials, sample_circuit
 ):
     """
-    Tests that requests are sent with Authorization header when credentials are provided
+    Tests that `submit_circuits` requests are sent with Authorization header when credentials are provided
     """
     tokens = prepare_tokens(300, 3600, **credentials)
-    expect_submit_circuits_request(base_url, tokens['access_token'], response_status=200)
+    expected_job_id = expect_submit_circuits_request(base_url, tokens['access_token'], response_status=200)
     client = IQMClient(base_url, **credentials)
-    client.submit_circuits(
+    created_job_id = client.submit_circuits(
         circuits=[Circuit.parse_obj(sample_circuit)],
         qubit_mapping={'Qubit A': 'QB1', 'Qubit B': 'QB2'},
         shots=1000,
     )
+    assert expected_job_id == created_job_id
+    unstub()
 
 
-def test_submit_circuits_raises_when_no_credentials_are_provided(base_url, credentials, sample_circuit):
+def test_submit_circuits_raises_when_auth_failed(base_url, credentials, sample_circuit):
     """
-    Tests that requests are sent with Authorization header when credentials are provided
-    """
-    tokens = prepare_tokens(300, 3600, **credentials)
-    expect_submit_circuits_request(base_url, tokens['access_token'], response_status=200)
-    client = IQMClient(base_url, **credentials)
-    client.submit_circuits(
-        circuits=[Circuit.parse_obj(sample_circuit)],
-        qubit_mapping={'Qubit A': 'QB1', 'Qubit B': 'QB2'},
-        shots=1000,
-    )
-
-
-def test_submit_circuits_when_no_credentials_are_provided(base_url, credentials, sample_circuit):
-    """
-    Tests that requests are sent with Authorization header when credentials are provided
+    Tests that submit_circuits raises when authentication fails
     """
     tokens = prepare_tokens(300, 3600, **credentials)
     expect_submit_circuits_request(base_url, tokens['access_token'], response_status=401)
@@ -132,6 +120,7 @@ def test_submit_circuits_when_no_credentials_are_provided(base_url, credentials,
             shots=1000,
         )
     assert str(e.value).startswith('Authentication failed')
+    unstub()
 
 
 def test_add_authorization_header_when_external_token_is_provided(base_url, tokens_dict):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -78,7 +78,7 @@ def test_get_initial_tokens_with_incomplete_credentials_from_env_variables(base_
 
 def test_add_authorization_header_when_credentials_are_provided(base_url, credentials):
     """
-    Tests that `get_run` requests are sent with Authorization header when credentials are provided
+    Tests that ``get_run`` requests are sent with Authorization header when credentials are provided
     """
     tokens = prepare_tokens(300, 3600, **credentials)
     job_id = expect_status_request(base_url, tokens['access_token'])

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -108,7 +108,7 @@ def test_add_authorization_header_on_submit_circuits_when_credentials_are_provid
 
 def test_submit_circuits_raises_when_auth_failed(base_url, credentials, sample_circuit):
     """
-    Tests that submit_circuits raises when authentication fails
+    Tests that ``submit_circuits`` raises ClientAuthenticationError when authentication fails
     """
     tokens = prepare_tokens(300, 3600, **credentials)
     expect_submit_circuits_request(base_url, tokens['access_token'], response_status=401)


### PR DESCRIPTION
Fetching the quantum architecture is the first step in e.g. `iqm-qiskit` and should provide a meaningful error message is the auth credentials are missing.