### PR TITLE
COMP-584 Improve multiversion documentation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,3 +61,4 @@ jobs:
         with:
           branch: gh-pages
           folder: build/sphinx/html
+          force: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 11.5
+============
+
+* Improve multiversion docs builds. `#75 <https://github.com/iqm-finland/iqm-client/pull/75>`_
+
 Version 11.4
 ============
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,11 +169,7 @@ mathjax3_config = {
 
 python_version = '.'.join(map(str, sys.version_info[0:2]))
 intersphinx_mapping = {
-    'sphinx': ('https://www.sphinx-doc.org/en/master', None),
     'python': ('https://docs.python.org/' + python_version, None),
-    'matplotlib': ('https://matplotlib.org/stable', None),
-    'numpy': ('https://numpy.org/doc/stable', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy', None),
 }
 
 extlinks = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ dev =
     tox == 3.26.0
 docs =
     sphinx == 4.5.0
-    sphinx-multiversion-contrib == 0.2.12
+    sphinx-multiversion-contrib == 0.2.13
     sphinx-book-theme == 0.3.3
 testing =
     black == 22.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,8 @@ extras =
 allowlist_externals =
     sphinx-multiversion
 commands =
-    sphinx-multiversion "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" -W --dev-name dev
+    python tox_docs_helper.py
+    sphinx-multiversion "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" -W --dev-name dev --skip-if-outputdir-exists
 
 [testenv:build]
 description =

--- a/tox_docs_helper.py
+++ b/tox_docs_helper.py
@@ -1,0 +1,49 @@
+# Tox helper file. Checks out the documentation branch and copies available
+# documentation versions to the build directory. Then, rebuilding the existing
+# versions can be skipped by ``sphinx-multiversion-contrib`` using flag
+# ``--skip-if-outputdir-exists``
+
+import os
+import shutil
+import tarfile
+
+from subprocess import Popen, PIPE
+
+
+TEMP_DIR = 'temp'
+DOCS_BUILD_DIR = 'build'
+DOCS_VERSIONS_DIR = 'versions'
+DOCS_BUILD_INNER_PATH = os.path.join(DOCS_BUILD_DIR, 'sphinx', 'html')
+TEMP_ARCHIVE_FILE = 'temp_archive.tar'
+
+DOCS_BRANCH = 'remotes/origin/gh-pages'
+
+
+# Delete stale directories if any
+
+if os.path.exists(TEMP_DIR):
+    shutil.rmtree(TEMP_DIR)
+
+if os.path.exists(DOCS_BUILD_DIR):
+    shutil.rmtree(DOCS_BUILD_DIR)
+
+# Create new directories
+
+os.makedirs(TEMP_DIR, exist_ok=True)
+os.makedirs(DOCS_BUILD_INNER_PATH, exist_ok=True)
+
+# Get available versions of documentation from Git branch as TAR archive
+
+Popen(['git', 'archive', DOCS_BRANCH, '-o', os.path.join(TEMP_DIR, TEMP_ARCHIVE_FILE)], stdout=PIPE, stderr=PIPE).wait()
+
+with tarfile.open(os.path.join(TEMP_DIR, TEMP_ARCHIVE_FILE), 'r') as f:
+    f.extractall(path=TEMP_DIR)
+
+# Copy directories of documentation versions to build directory
+
+shutil.move(os.path.join(TEMP_DIR, DOCS_VERSIONS_DIR), DOCS_BUILD_INNER_PATH)
+
+# Delete temp directories
+
+if os.path.exists(TEMP_DIR):
+    shutil.rmtree(TEMP_DIR)


### PR DESCRIPTION
Configure Tox to skip rebuilding documentation for the versions that already exist.

Implementation uses a Python helper file to check out available versions of documentation from Git branch. The helper file is OS agnostic
