### PR TITLE
Add get_calibration_data function

### DIFF
--- a/src/iqm_client/iqm_client.py
+++ b/src/iqm_client/iqm_client.py
@@ -1128,3 +1128,23 @@ class IQMClient:
         if bearer_token:
             headers['Authorization'] = bearer_token
         return headers
+
+    def get_calibration_data(self, calibration_set_id: UUID = None):
+        """
+        Return json response from calibration endpoint.
+        Optionally you can input a calibration set id (UUID) to query historical results
+
+        Args:
+            calibration_set_id: calibration set id to query. Defaults to None, returning the latest data.
+
+        Returns:
+            Calibration data in json format
+        """
+        headers = self._default_headers()
+        url = os.path.join(self._base_url, 'calibration')
+        if calibration_set_id:
+            url = os.path.join(url, str(calibration_set_id))
+        response = requests.get(url, headers=headers, timeout=REQUESTS_TIMEOUT)
+        response.raise_for_status()
+
+        return response.json()


### PR DESCRIPTION
The PR would add a function to IQMClient that would allow users and adapter libraries to directly query the `/calibration` API endpoint and return calibration data. This is currently a function used internally and it useful because it allows you to utilise the same authentication session as IQMClient uses for job submission. 

Regarding adding tests. I believe a simple MockJsonResponse test would be enough similar to `test_get_quantum_architecture`. However I would need to define perhaps a few things:
- `sample_calibration` similar to `sample_quantum_architecture`
- Calibration Specification? Similar to `QuantumArchitectureSpecification`
- Opaque UUID for `quality_metrics_set_id_value` for example for the `sample_calibration`. 

Looking forward to your response,
Jake
