### PR TITLE
Make REQUESTS_TIMEOUT optional from environment variable

### DIFF
--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -148,7 +148,7 @@ import warnings
 from pydantic import BaseModel, Field, StrictStr, validate_model, validator
 import requests
 
-REQUESTS_TIMEOUT = 60
+REQUESTS_TIMEOUT = int(os.environ.get('IQM_CLIENT_REQUESTS_TIMEOUT', 60))
 
 DEFAULT_TIMEOUT_SECONDS = 900
 SECONDS_BETWEEN_CALLS = float(os.environ.get('IQM_CLIENT_SECONDS_BETWEEN_CALLS', 1.0))


### PR DESCRIPTION
Hi, this pull requests adds the option to set the iqm client requests timeout duration from an environment variable. This may be needed in instances where, for example, the returning of the results to the client takes longer than the default 60s. 