### PR TITLE
Use get_run_status() instead of get_run() to check status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 14.2
+============
+
+* Use ``get_run_status`` instead of ``get_run`` to check job status in ``wait_for_compilation`` and ``wait_for_results``. `#100 <https://github.com/iqm-finland/iqm-client/pull/100>`_
+
 Version 14.1
 ============
 

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -952,9 +952,9 @@ class IQMClient:
         """
         start_time = datetime.now()
         while (datetime.now() - start_time).total_seconds() < timeout_secs:
-            results = self.get_run(job_id)
-            if results.status != Status.PENDING_COMPILATION:
-                return results
+            status = self.get_run_status(job_id).status
+            if status != Status.PENDING_COMPILATION:
+                return self.get_run(job_id)
             time.sleep(SECONDS_BETWEEN_CALLS)
         raise APITimeoutError(f"The job compilation didn't finish in {timeout_secs} seconds.")
 
@@ -976,9 +976,9 @@ class IQMClient:
         """
         start_time = datetime.now()
         while (datetime.now() - start_time).total_seconds() < timeout_secs:
-            results = self.get_run(job_id)
-            if results.status not in (Status.PENDING_COMPILATION, Status.PENDING_EXECUTION):
-                return results
+            status = self.get_run_status(job_id).status
+            if status not in (Status.PENDING_COMPILATION, Status.PENDING_EXECUTION):
+                return self.get_run(job_id)
             time.sleep(SECONDS_BETWEEN_CALLS)
         raise APITimeoutError(f"The job didn't finish in {timeout_secs} seconds.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -517,7 +517,7 @@ def post_jobs_args(
 def get_jobs_args(
     user_agent: Optional[str] = f'{DIST_NAME} {__version__}', access_token: Optional[str] = None
 ) -> dict[str, Any]:
-    """Returns expected kwargs of POST /jpbs request"""
+    """Returns expected kwargs of POST /jobs request"""
     headers = {}
     if user_agent is not None:
         headers['User-Agent'] = user_agent

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -278,14 +278,21 @@ def test_get_run_status_for_missing_run(sample_client, jobs_url, missing_run_id)
 
 
 def test_waiting_for_compilation(
-    sample_client, existing_job_url, pending_compilation_job_result, pending_execution_job_result, existing_run_id
+    sample_client,
+    existing_job_status_url,
+    pending_compilation_status,
+    pending_execution_status,
+    existing_job_url,
+    pending_execution_job_result,
+    existing_run_id,
 ):
     """
     Tests waiting for compilation for an existing task
     """
-    expect(requests, times=3).get(existing_job_url, **get_jobs_args()).thenReturn(
-        pending_compilation_job_result
-    ).thenReturn(pending_compilation_job_result).thenReturn(pending_execution_job_result)
+    expect(requests, times=3).get(existing_job_status_url, **get_jobs_args()).thenReturn(
+        pending_compilation_status
+    ).thenReturn(pending_compilation_status).thenReturn(pending_execution_status)
+    expect(requests, times=1).get(existing_job_url, **get_jobs_args()).thenReturn(pending_execution_job_result)
 
     assert sample_client.wait_for_compilation(existing_run_id).status == Status.PENDING_EXECUTION
 
@@ -296,8 +303,10 @@ def test_waiting_for_compilation(
 def test_wait_for_compilation_adds_user_agent_with_signature(
     client_with_signature,
     client_signature,
+    existing_job_status_url,
+    pending_compilation_status,
+    pending_execution_status,
     existing_job_url,
-    pending_compilation_job_result,
     pending_execution_job_result,
     existing_run_id,
 ):
@@ -306,10 +315,11 @@ def test_wait_for_compilation_adds_user_agent_with_signature(
     """
     assert client_signature in client_with_signature._signature
     expect(requests, times=3).get(
+        existing_job_status_url, **get_jobs_args(user_agent=client_with_signature._signature)
+    ).thenReturn(pending_compilation_status).thenReturn(pending_compilation_status).thenReturn(pending_execution_status)
+    expect(requests, times=1).get(
         existing_job_url, **get_jobs_args(user_agent=client_with_signature._signature)
-    ).thenReturn(pending_compilation_job_result).thenReturn(pending_compilation_job_result).thenReturn(
-        pending_execution_job_result
-    )
+    ).thenReturn(pending_execution_job_result)
 
     assert client_with_signature.wait_for_compilation(existing_run_id).status == Status.PENDING_EXECUTION
 
@@ -319,18 +329,21 @@ def test_wait_for_compilation_adds_user_agent_with_signature(
 
 def test_waiting_for_results(
     sample_client,
+    existing_job_status_url,
+    pending_compilation_status,
+    pending_execution_status,
+    ready_status,
     existing_job_url,
-    pending_compilation_job_result,
-    pending_execution_job_result,
     ready_job_result,
     existing_run_id,
 ):
     """
     Tests waiting for results for an existing task
     """
-    expect(requests, times=3).get(existing_job_url, **get_jobs_args()).thenReturn(
-        pending_compilation_job_result
-    ).thenReturn(pending_execution_job_result).thenReturn(ready_job_result)
+    expect(requests, times=3).get(existing_job_status_url, **get_jobs_args()).thenReturn(
+        pending_compilation_status
+    ).thenReturn(pending_execution_status).thenReturn(ready_status)
+    expect(requests, times=1).get(existing_job_url, **get_jobs_args()).thenReturn(ready_job_result)
 
     assert sample_client.wait_for_results(existing_run_id).status == Status.READY
 
@@ -341,9 +354,11 @@ def test_waiting_for_results(
 def test_wait_for_results_adds_user_agent_with_signature(
     client_with_signature,
     client_signature,
+    existing_job_status_url,
+    pending_compilation_status,
+    pending_execution_status,
+    ready_status,
     existing_job_url,
-    pending_compilation_job_result,
-    pending_execution_job_result,
     ready_job_result,
     existing_run_id,
 ):
@@ -352,8 +367,11 @@ def test_wait_for_results_adds_user_agent_with_signature(
     """
     assert client_signature in client_with_signature._signature
     expect(requests, times=3).get(
+        existing_job_status_url, **get_jobs_args(user_agent=client_with_signature._signature)
+    ).thenReturn(pending_compilation_status).thenReturn(pending_execution_status).thenReturn(ready_status)
+    expect(requests, times=1).get(
         existing_job_url, **get_jobs_args(user_agent=client_with_signature._signature)
-    ).thenReturn(pending_compilation_job_result).thenReturn(pending_execution_job_result).thenReturn(ready_job_result)
+    ).thenReturn(ready_job_result)
 
     assert client_with_signature.wait_for_results(existing_run_id).status == Status.READY
 


### PR DESCRIPTION
Previously, `wait_for_results()` and `wait_for_compilation()` used `get_run()` to check the status of the job. The RunResult returned by `get_jobs()` contains metadata which contains the original job request, so if the original job request was large, it could take a long time to send and decode the RunResult JSON even before job results are ready. This meant that, for example, `wait_for_results()` might end up checking the status only every 30 seconds (because of the RunResult overhead) while it was supposed to check the status once every second. With unlucky timing, this could then lead to a situation where the job has already finished on the server, but `wait_for_results()` returns `APITimeoutError` long after that.

This MR fixes the problem by using `get_run_status()` instead of `get_run()` to check the status in `wait_for_results()` and `wait_for_compilation()`, so that only RunStatus is polled, not RunResult. 