### PR TITLE
COMP-1175: Update HTTP interface specification to match the new design

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=65.4.1", "setuptools_scm[toml]>=7"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "iqm-client"
+name = "iqm-client-ndonis"
 dynamic = ["version"]
 description = "Client library for accessing an IQM quantum computer"
 authors = [{name="IQM Finland Oy", email="developers@meetiqm.com"}]

--- a/src/iqm/iqm_client/__init__.py
+++ b/src/iqm/iqm_client/__init__.py
@@ -18,7 +18,7 @@ from importlib.metadata import PackageNotFoundError, version
 from iqm.iqm_client.iqm_client import *
 
 try:
-    DIST_NAME = "iqm-client"
+    DIST_NAME = "iqm-client-ndonis"
     __version__ = version(DIST_NAME)
 except PackageNotFoundError:
     __version__ = "unknown"

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -174,6 +174,10 @@ SUPPORTED_INSTRUCTIONS: dict[str, dict[str, Any]] = {
         'arity': 2,
         'args': {},
     },
+    'move': {
+        'arity': 2,
+        'args': {},
+    },
     'measure': {
         'arity': -1,
         'args': {
@@ -528,8 +532,8 @@ class QuantumArchitectureSpecification(BaseModel):
 
     name: str = Field(...)
     """name of the quantum architecture"""
-    operations: list[str] = Field(...)
-    """list of operations supported by this quantum architecture"""
+    operations: dict[str, list[list[str]]] = Field(...)
+    """the operations supported by this quantum architecture, mapped to the allowed connections"""
     qubits: list[str] = Field(...)
     """list of qubits of this quantum architecture"""
     qubit_connectivity: list[list[str]] = Field(...)

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -752,7 +752,7 @@ class IQMClient:
         self._base_url = url
         self._signature = f'{platform.platform(terse=True)}'
         self._signature += f', python {platform.python_version()}'
-        self._signature += f', iqm-client {version("iqm-client")}'
+        self._signature += f', iqm-client {version("iqm-client-ndonis")}'
         if client_signature:
             self._signature += f', {client_signature}'
         self._tokens_file = tokens_file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,7 +393,7 @@ def sample_quantum_architecture():
             'name': 'hercules',
             'qubits': ['QB1', 'QB2'],
             'qubit_connectivity': [['QB1', 'QB2']],
-            'operations': ['phased_rx', 'CZ'],
+            'operations': {'phased_rx': [['QB1'], ['QB2']], 'CZ': [['QB1', 'QB2']]},
         }
     }
 


### PR DESCRIPTION
Update architecture model based on the new design. This will break backwards-compatibility with older versions. 