### PR TITLE
Use GitHub Action Trusted Publisher for PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,18 +1,13 @@
-name: Upload to PyPI and publish documentation
+name: Upload package to PyPI and publish documentation
 
 on:
   release:
     types: [published]
   workflow_dispatch:
   workflow_call:
-    secrets:
-      PYPI_USER:
-        required: true
-      PYPI_PASSWORD:
-        required: true
 
 jobs:
-  push_to_pypi:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,14 +21,30 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-      - name: Build and publish
-        run: |
-          tox -e build
-          tox -e publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          python -m pip install build==1.0.3
+      - name: Build distribution
+        run: python -m build
+      - name: Store distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ./dist
+
+  push_to_pypi:
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/iqm-client
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distribution packages
+        uses: actions/download-artifact@v4
+      - name: Publish distribution packages to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   publish_docs:
     runs-on: ubuntu-latest
@@ -86,7 +97,7 @@ jobs:
           pip-licenses --format=confluence --with-urls > licenses.txt
           cat -n licenses.txt | sort -uk2 | sort -n | cut -f2- > tmp && mv tmp licenses.txt  # remove duplicate lines
       - name: Upload license information artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dependencies-licenses
           path: licenses.txt

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -40,7 +40,4 @@ jobs:
   # created by the above job create_tag_and_release. Here we trigger the said workflow manually.
   trigger_publishing:
     needs: create_tag_and_release
-    uses: iqm-finland/iqm-client/.github/workflows/publish.yml@main
-    secrets:
-      PYPI_USER: ${{ secrets.PYPI_USER }}
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    uses: ./.github/workflows/publish.yml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 16.2
+============
+
+* Use GitHub Action as a Trusted Publisher to publish packages to PyPI. `#116 <https://github.com/iqm-finland/iqm-client/pull/116>`_
+
 Version 16.1
 ============
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,18 +59,3 @@ skip_install = True
 changedir = {toxinidir}
 commands =
     python -m build
-
-[testenv:publish]
-description =
-    Publish the package you have been developing to a package index server.
-deps =
-    twine == 4.0.2
-skip_install = True
-changedir = {toxinidir}
-passenv =
-    TWINE_USERNAME
-    TWINE_PASSWORD
-    TWINE_REPOSITORY_URL
-commands =
-    python -m twine check dist/*
-    python -m twine upload --verbose dist/*


### PR DESCRIPTION
- Separate ```push_to_pypi``` job into two jobs: ```build``` and ```push_to_pypi```
- Use ```publish``` workflow file from current feature branch rather than ```main``` branch
- Do not use ```tox``` in ```publish``` workflow to build and upload package
- Remove ```twine``` dependency
- Remove ```publish``` configuration from ```tox```
- Remove references to PyPI secrets