### PR TITLE
Remove :file: anchor from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ corresponding tag, and running the docs builder. For example, to build the docum
     $ tox run -e docs
 
 ``tox run -e docs`` will build the documentation at ``./build/sphinx/html``. This command requires the ``tox,``, ``sphinx`` and 
-``sphinx-book-theme`` Python packages (see the ``docs`` optional dependency in :file:`pyproject.toml`); 
+``sphinx-book-theme`` Python packages (see the ``docs`` optional dependency in ``pyproject.toml``); 
 you can install the necessary packages with ``pip install -e ".[dev,docs]"``
 
 Copyright


### PR DESCRIPTION
This is needed for PyPI publishing