### PR TITLE
Allow inspecting a RunRequest without submitting it for execution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 17.8
+============
+
+* Allow inspecting a run request before submitting it for execution. `#129 <https://github.com/iqm-finland/iqm-client/pull/129>`_
+
 Version 17.7
 ============
 

--- a/INTEGRATION_GUIDE.rst
+++ b/INTEGRATION_GUIDE.rst
@@ -165,6 +165,9 @@ Once set, this environment variable will control network request timeouts for IQ
 
 Set ``IQM_CLIENT_SECONDS_BETWEEN_CALLS`` to control the polling frequency when waiting for compilation and run results with IQM Client methods ``wait_for_compilation`` and ``wait_for_results``. The default value is set to 1 second.
 
+Set ``IQM_CLIENT_DEBUG=1`` to print the run request when it is submitted for execution in
+:meth:`.IQMClient.submit_circuits` or :meth:`.IQMClient.submit_run_request`. To inspect the run request without sending
+it for execution, use :meth:`.IQMClient.create_run_request`.
 
 Integration testing
 -------------------


### PR DESCRIPTION
Extracts the creation and submission of run request from `submit_circuits()` into separate functions. This allows inspecting a run request programmatically, before/without actually submitting it for execution. From user's perspective, there is no change to `submit_circuits()` so this is not a breaking change. Also adds `IQM_CLIENT_DEBUG` environment variable for printing a run request when it is actually submitted.