### PR TITLE
Bugfixes, better circuit validation, docs updated.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,13 +8,12 @@ Version 18.1
 * Added ``isort`` formatting to the tox configuration, so it is automatically run when running
   ``tox -e format``. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Bugfix: Fix the issue where the :class:`CircuitCompilationOptions` was not used in local circuit
-  validation when using the :meth:`submit_circuit` method (COMP-1491).
+  validation when using the :meth:`submit_circuit` method. Improved testing to catch the bug.
   `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
-* Improved testing to catch the bug above.
 * Bugfix: MOVE gate validation now also works with more than one resonator. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * More specific validation and transpilation errors. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Docs updated: mid-circuit measurements are allowed on stations with ``cocos >= 30.2``. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
-* Integration guide updated.
+* Integration guide updated. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 
 Version 18.0
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Version 18.1
   `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Improved testing to catch the bug above.
 * Bugfix: MOVE gate validation now also works with more than one resonator. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
+* More specific validation and transpilation errors. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Docs updated: mid-circuit measurements are allowed on stations with ``cocos >= 30.2``. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 
 Version 18.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Version 18.1
 * Bugfix: MOVE gate validation now also works with more than one resonator. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * More specific validation and transpilation errors. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Docs updated: mid-circuit measurements are allowed on stations with ``cocos >= 30.2``. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
+* Integration guide updated.
 
 Version 18.0
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,13 +5,14 @@ Changelog
 Version 18.1
 ============
 
-* Added `isort` formating to the tox configuration, so it is automatically run when running
+* Added ``isort`` formating to the tox configuration, so it is automatically run when running
   ``tox -e format``. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Bugfix: Fix the issue where the :class:`CircuitCompilationOptions` was not used in local circuit
   validation when using the :meth:`submit_circuit` method (COMP-1491).
   `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Improved testing to catch the bug above.
-* Docs updated: mid-circuit measurements are allowed on stations with ``cocos >= 30.2``.
+* Bugfix: MOVE gate validation now also works with more than one resonator. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
+* Docs updated: mid-circuit measurements are allowed on stations with ``cocos >= 30.2``. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 
 Version 18.0
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog
 Version 18.1  
 ============
 
-* Added `isort` formating to the tox configuration, so it is automatically run when running `tox -e format`.
-* Bugfix: Fix the issue where the `CircuitCompilationOptions` was not used in local circuit validation when using the `submit_circuit` method (COMP-1491).  
+* Added `isort` formating to the tox configuration, so it is automatically run when running `tox -e format`. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
+* Bugfix: Fix the issue where the `CircuitCompilationOptions` was not used in local circuit validation when using the `submit_circuit` method (COMP-1491).  `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Improved testing to catch the bug above.
 
 Version 18.0  

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,25 +2,29 @@
 Changelog
 =========
 
-Version 18.1  
+Version 18.1
 ============
 
-* Added `isort` formating to the tox configuration, so it is automatically run when running `tox -e format`. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
-* Bugfix: Fix the issue where the `CircuitCompilationOptions` was not used in local circuit validation when using the `submit_circuit` method (COMP-1491).  `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
+* Added `isort` formating to the tox configuration, so it is automatically run when running
+  ``tox -e format``. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
+* Bugfix: Fix the issue where the :class:`CircuitCompilationOptions` was not used in local circuit
+  validation when using the :meth:`submit_circuit` method (COMP-1491).
+  `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Improved testing to catch the bug above.
+* Docs updated: mid-circuit measurements are allowed on stations with ``cocos >= 30.2``.
 
-Version 18.0  
+Version 18.0
 ============
 
 * Added the naive MOVE transpilation method for unified transpilation behavior for different external APIs. `#124 <https://github.com/iqm-finland/iqm-client/pull/124>`_
 * Added class for compilation options :class:`CircuitCompilationOptions` to allow for more fine-grained control over the compilation process. (breaking change)
-    * :meth:`IQMClient.submit_circuit` now takes a :class:`CircuitCompilationOptions` parameter instead of ``max_circuit_duration_over_t2`` and ``heralding_mode``.
-    * Moved the existing ``max_circuit_duration_over_t2`` parameter to :class:`CircuitCompilationOptions`.
-    * Moved the existing ``heralding_mode`` parameter to :class:`CircuitCompilationOptions`.
-    * Introduced new option ``move_gate_validation`` to turn off MOVE gate validation during compilation (ADVANCED).
-    * Introduced new option ``move_gate_frame_tracking`` to turn off frame tracking for the MOVE gate (ADVANCED).
-    * New options can only be used on stations with `CoCoS` version 29.9 or later that support the MOVE gate instruction. Otherwise, the options will be ignored. 
 
+  * :meth:`IQMClient.submit_circuit` now takes a :class:`CircuitCompilationOptions` parameter instead of ``max_circuit_duration_over_t2`` and ``heralding_mode``.
+  * Moved the existing ``max_circuit_duration_over_t2`` parameter to :class:`CircuitCompilationOptions`.
+  * Moved the existing ``heralding_mode`` parameter to :class:`CircuitCompilationOptions`.
+  * Introduced new option ``move_gate_validation`` to turn off MOVE gate validation during compilation (ADVANCED).
+  * Introduced new option ``move_gate_frame_tracking`` to turn off frame tracking for the MOVE gate (ADVANCED).
+  * New options can only be used on stations with ``CoCoS`` version 29.9 or later that support the MOVE gate instruction. Otherwise, the options will be ignored. 
 
 Version 17.8
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 18.1  
+============
+
+* Added `isort` formating to the tox configuration, so it is automatically run when running `tox -e format`.
+* Bugfix: Fix the issue where the `CircuitCompilationOptions` was not used in local circuit validation when using the `submit_circuit` method (COMP-1491).  
+* Improved testing to catch the bug above.
+
 Version 18.0  
 ============
 
@@ -12,6 +19,7 @@ Version 18.0
     * Moved the existing ``heralding_mode`` parameter to :class:`CircuitCompilationOptions`.
     * Introduced new option ``move_gate_validation`` to turn off MOVE gate validation during compilation (ADVANCED).
     * Introduced new option ``move_gate_frame_tracking`` to turn off frame tracking for the MOVE gate (ADVANCED).
+    * New options can only be used on stations with `CoCoS` version 29.9 or later that support the MOVE gate instruction. Otherwise, the options will be ignored. 
 
 
 Version 17.8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Version 18.1
 * More specific validation and transpilation errors. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Docs updated: mid-circuit measurements are allowed on stations with ``cocos >= 30.2``. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Integration guide updated. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
+* Circuit validation: All measurement keys must be unique. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 
 Version 18.0
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 18.1
 ============
 
-* Added ``isort`` formating to the tox configuration, so it is automatically run when running
+* Added ``isort`` formatting to the tox configuration, so it is automatically run when running
   ``tox -e format``. `#130 <https://github.com/iqm-finland/iqm-client/pull/130>`_
 * Bugfix: Fix the issue where the :class:`CircuitCompilationOptions` was not used in local circuit
   validation when using the :meth:`submit_circuit` method (COMP-1491).

--- a/INTEGRATION_GUIDE.rst
+++ b/INTEGRATION_GUIDE.rst
@@ -194,15 +194,15 @@ transpile the circuits against that representation, then use qubit mapping along
 circuits to map from the local representation to the IQM representation of qubit names.  We
 discourage exposing this feature to end users of the quantum computing framework.
 
-Note on circuit duration
-------------------------
+Note on circuit duration check
+------------------------------
 
 Before performing circuit execution, IQM server checks how long it would take to run each circuit.
 If any circuit in a job would take too long to execute compared to the T2 time of the qubits,
 the server will disqualify the job, not execute any circuits, and return a detailed error message.
-In some special cases, it makes sense to disable this check by changing the default value of parameter
-``max_circuit_duration_over_t2`` of :meth:`.IQMClient.submit_circuits` to ``0.0`` or by making it large
-enough for the job to pass the check. If the value is not set at all, the server default value will be used.
+In some special cases, it makes sense to adjust or disable this check using
+the :attr:`max_circuit_duration_over_t2` attribute of :class:`.CircuitCompilationOptions`,
+and then passing the options to :meth:`.IQMClient.submit_circuits`.
 
 Note on environment variables
 -----------------------------

--- a/INTEGRATION_GUIDE.rst
+++ b/INTEGRATION_GUIDE.rst
@@ -2,17 +2,22 @@
 Integration Guide
 =================
 
-IQM client is designed to be the Python adapter to IQM's quantum computers for application-level quantum computing frameworks.
-For example integrations maintained by IQM, please refer to the `Qiskit <https://github.com/iqm-finland/qiskit-on-iqm>`_ and `Cirq <https://github.com/iqm-finland/cirq-on-iqm>`_ packages.
+IQM client is designed to be the Python adapter to IQM's quantum computers for application-level
+quantum computing frameworks.  For example integrations maintained by IQM, please refer to the
+`Qiskit <https://github.com/iqm-finland/qiskit-on-iqm>`_ and
+`Cirq <https://github.com/iqm-finland/cirq-on-iqm>`_ packages.
 
-IQM client offers the functionality to submit circuits to an IQM quantum computer, query a job or a job status, and retrieve the quantum architecture of the quantum computer.
+IQM client offers the functionality to submit quantum circuits to an IQM quantum computer, query a
+job or a job status, and retrieve the quantum architecture of the quantum computer.
 
-The following sections illustrate how to integrate IQM quantum computers into your quantum computing framework.
+The following sections illustrate how to integrate IQM quantum computers into your quantum computing
+framework.
 
 Code example
 ------------
 
-Initialising the IQM client is simple, and in case you perform authentication as described below, requires only the URL of the IQM quantum computer.
+Initialising the IQM client is simple, and in case you perform authentication as described below,
+requires only the URL of the IQM quantum computer.
 
 .. code-block:: python
 
@@ -22,7 +27,8 @@ Initialising the IQM client is simple, and in case you perform authentication as
 
     iqm_client = IQMClient(server_url)
 
-To submit a circuit, the circuit has to be specified in the IQM transfer format.
+To submit a quantum circuit for execution, it has to be specified using the :class:`.Circuit` class.
+The available native instructions are documented in the :class:`.Instruction` class.
 
 .. code-block:: python
 
@@ -30,10 +36,10 @@ To submit a circuit, the circuit has to be specified in the IQM transfer format.
 
     instructions = (
         Instruction(
-            name="phased_rx", qubits=("QB1",), args={"phase_t": 0.7, "angle_t": 0.25}
+            name="prx", qubits=("QB1",), args={"phase_t": 0.7, "angle_t": 0.25}
         ),
         Instruction(name="cz", qubits=("QB1", "QB2"), args={}),
-        Instruction(name="measurement", qubits=("QB2",), args={"key": "Qubit 2"}),
+        Instruction(name="measure", qubits=("QB2",), args={"key": "Qubit 2"}),
     )
 
     circuit = Circuit(name="quantum_circuit", instructions=instructions)
@@ -50,12 +56,12 @@ Then the circuit can be submitted, and its status and result can be queried with
 
 A dict containing arbitrary metadata can be attached to the circuit before submitting it for
 execution. The attached metadata should consist only of values of JSON serializable datatypes.
-A utility function ``util.to_json_dict`` can be used to convert supported datatypes,
-e.g. ``numpy.ndarray``, to equivalent JSON serializable types.
+A utility function :func:`~.iqm_client.util.to_json_dict` can be used to convert supported datatypes,
+e.g. :class:`numpy.ndarray`, to equivalent JSON serializable types.
 
-The progress of the job can be followed with ``iqm_client.get_run_status``. Once the job is ready,
-the results can be read with ``iqm_client.get_run``. Both of these actions are combined in
-``iqm_client.wait_for_results`` which waits until the job is ready and then returns the result.
+The progress of the job can be followed with :meth:`.IQMClient.get_run_status`. Once the job is ready,
+the results can be read with :meth:`.IQMClient.get_run`. Both of these actions are combined in
+:meth:`.IQMClient.wait_for_results` which waits until the job is ready and then returns the result.
 
 In addition to the actual results, job result contains also metadata of the job execution.
 The metadata includes the original request, ID of the calibration set used in the execution, and
@@ -65,7 +71,7 @@ Job phases and related timestamps
 ---------------------------------
 
 The timestamps returned with job results are stored as an optional dict called ``timestamps`` in the metadata of
-RunResult of the job. Each timestamp is stored in the dict with a key describing the point in job processing where
+:class:`.RunResult` of the job. Each timestamp is stored in the dict with a key describing the point in job processing where
 the timestamp was stored. For example, the timestamp stored at the start of circuit compilation step is stored with
 key ``compile_start``. Other timestamps are stored in the same way, with keys containing the step name,
 ``compile``, ``submit`` or ``execution``, and either a ``_start`` or ``_end`` suffix. In addition, there are
@@ -99,13 +105,13 @@ to manage the authentication tokens and store them into a file. IQM client can t
 the token from the file and use it for authentication. The file path can be provided to
 IQM client in environment variable ``IQM_TOKENS_FILE``.
 Alternatively, the tokens file path can be provided as argument ``tokens_file`` to
-``IQMClient`` constructor.
+:class:`.IQMClient` constructor.
 
 2. It is also possible to use plaintext token obtained from a server dashboard. These
 tokens may have longer lifespan than access tokens generated by Cortex CLI, and thus
 IQM client won't attempt to refresh them. The generated token can be provided to IQM
 client in environment variable ``IQM_TOKEN``.
-Alternatively, the token can be provided as argument ``token`` to ``IQMClient``
+Alternatively, the token can be provided as argument ``token`` to :class:`.IQMClient`
 constructor.
 
 3. The third way is to provide server URL, username and password for obtaining the
@@ -114,33 +120,45 @@ the authentication server and read and refresh the token as needed. The server U
 username and password can be provided to IQM client in environment variables
 ``IQM_AUTH_SERVER``, ``IQM_AUTH_USERNAME`` and ``IQM_AUTH_PASSWORD``.
 Alternatively, the values can be provided as arguments ``auth_server_url``,
-``username`` and ``password`` to ``IQMClient`` constructor.
+``username`` and ``password`` to :class:`.IQMClient` constructor.
 Note, that all the values must be provided as either environment variables or
 as constructor arguments, not mixed.
 
 Circuit transpilation
 ---------------------
 
-IQM does not provide an open source circuit transpilation library, so this will have to be supplied by the quantum computing framework or a third party library.
-To obtain the necessary information for circuit transpilation, :meth:`IQMClient.get_quantum_architecture` returns the names of the qubits, qubit connectivity,
-and native operations. This information should enable circuit transpilation for IQM quantum architectures.
+IQM does not provide an open source circuit transpilation library, so this will have to be supplied
+by the quantum computing framework or a third party library.  To obtain the necessary information
+for circuit transpilation, :meth:`.IQMClient.get_quantum_architecture` returns the names of the
+qubits, qubit connectivity, and native operations. This information should enable circuit
+transpilation for IQM quantum architectures.
 
-The notable exception is the transpilation of MOVE gates for IQM quantum computers with computational resonators, for which some specialized transpilation logic is provided.
-The MOVE gate moves the state of a qubit to an empty computational resonator, and vice versa, so that the qubit can interact with other qubits connected to the resonator.
-For this, we provide users with two transpilation functions: :func:`transpile_insert_moves` and :func:`transpile_remove_moves`.
-These functions can be used to insert or remove MOVE gates from the circuit, respectively. 
+The notable exception is the transpilation of MOVE gates for IQM quantum computers with
+computational resonators, for which some specialized transpilation logic is provided.  The MOVE gate
+moves the state of a qubit to an empty computational resonator, and vice versa, so that the qubit
+can interact with other qubits connected to the resonator.  For this, we provide users with two
+transpilation functions: :func:`.transpile_insert_moves` and :func:`.transpile_remove_moves`.  These
+functions can be used to insert or remove MOVE gates from the circuit, respectively.
 
-:meth:`transpile_insert_moves` is a transpiler pass for inserting MOVE gates into a circuit for devices with a computational resonator. 
-It assumes that the circuit is already transpiled by third party software to an architecture where the computational resonator has been abstracted away.
-To abstract away the computational resonator, the connectivity graph is modified such that all the qubits connected to a common resonator are instead connected directly to each other.
-The function can take a ``qubit_mapping`` to rename the qubits in the circuit to match the physical qubit names.
-Additionally, the function can take the optional argument ``existing_moves`` to specify how this transpiler pass should handle the case where some MOVE gates are already present in the circuit. The options are specified by the enum :class:`ExistingMoveHandlingOptions`.
-By default the function warns the user if MOVE gates are already present in the circuit but the ``existing_moves`` argument is not given, before proceeding to remove the existing MOVE gates and inserting new ones. 
+:func:`.transpile_insert_moves` is a transpiler pass for inserting MOVE gates into a circuit for
+devices with a computational resonator.  It assumes that the circuit is already transpiled by third
+party software to an architecture where the computational resonator has been abstracted away.  To
+abstract away the computational resonator, the connectivity graph is modified such that all the
+qubits connected to a common resonator are instead connected directly to each other.  The function
+can take a ``qubit_mapping`` to rename the qubits in the circuit to match the physical qubit names.
+Additionally, the function can take the optional argument ``existing_moves`` to specify how this
+transpiler pass should handle the case where some MOVE gates are already present in the circuit. The
+options are specified by the enum :class:`.ExistingMoveHandlingOptions`.  By default the function
+warns the user if MOVE gates are already present in the circuit but the ``existing_moves`` argument
+is not given, before proceeding to remove the existing MOVE gates and inserting new ones.
 
-:meth:`transpile_remove_moves` is a helper function for :meth:`transpile_insert_moves` to remove existing MOVE gates from a quantum circuit.
-It can be also used standalone to remove the MOVE gates from an existing circuit such that it can be used on a device without a computational resonator, or optimized by third party software that does not support the MOVE gate.
-For example, a user might want to run a circuit that was originally transpiled for a device with a computational resonator on a device without a computational resonator.
-This function allows the user to remove the MOVE gates from the circuit before transpiling it to another quantum architecture.
+:func:`.transpile_remove_moves` is a helper function for :func:`.transpile_insert_moves` to remove
+existing MOVE gates from a quantum circuit.  It can be also used standalone to remove the MOVE gates
+from an existing circuit such that it can be used on a device without a computational resonator, or
+optimized by third party software that does not support the MOVE gate.  For example, a user might
+want to run a circuit that was originally transpiled for a device with a computational resonator on
+a device without a computational resonator.  This function allows the user to remove the MOVE gates
+from the circuit before transpiling it to another quantum architecture.
 
 
 .. code-block:: python
@@ -167,11 +185,14 @@ This function allows the user to remove the MOVE gates from the circuit before t
 Note on qubit mapping
 ---------------------
 
-We encourage to transpile circuits to use the physical IQM qubit names before submitting them to IQM quantum computers.
-In case the quantum computing framework does not allow for this, providing a qubit mapping can do the translation from the framework qubit names to IQM qubit names.
-Note, that qubit mapping is not supposed to be associated with individual circuits, but rather with the entire job request to IQM server.
-Typically, you would have some local representation of the QPU and transpile the circuits against that representation, then use qubit mapping along with the generated circuits to map from the local representation to the IQM representation of qubit names.
-We discourage exposing this feature to end users of the quantum computing framework.
+We encourage to transpile circuits to use the physical IQM qubit names before submitting them to IQM
+quantum computers.  In case the quantum computing framework does not allow for this, providing a
+qubit mapping can do the translation from the framework qubit names to IQM qubit names.  Note, that
+qubit mapping is not supposed to be associated with individual circuits, but rather with the entire
+job request to IQM server.  Typically, you would have some local representation of the QPU and
+transpile the circuits against that representation, then use qubit mapping along with the generated
+circuits to map from the local representation to the IQM representation of qubit names.  We
+discourage exposing this feature to end users of the quantum computing framework.
 
 Note on circuit duration
 ------------------------
@@ -180,13 +201,15 @@ Before performing circuit execution, IQM server checks how long it would take to
 If any circuit in a job would take too long to execute compared to the T2 time of the qubits,
 the server will disqualify the job, not execute any circuits, and return a detailed error message.
 In some special cases, it makes sense to disable this check by changing the default value of parameter
-``max_circuit_duration_over_t2`` of :meth:`IQMClient.submit_circuits` to ``0.0`` or by making it large
+``max_circuit_duration_over_t2`` of :meth:`.IQMClient.submit_circuits` to ``0.0`` or by making it large
 enough for the job to pass the check. If the value is not set at all, the server default value will be used.
 
 Note on environment variables
 -----------------------------
 
-Set ``IQM_CLIENT_REQUESTS_TIMEOUT`` environment variable to override the network requests default timeout value. The default value is 60 seconds and might not be sufficient when fetching run results of larger circuits via slow network connections.
+Set :envvar:`IQM_CLIENT_REQUESTS_TIMEOUT` environment variable to override the network requests default
+timeout value. The default value is 60 seconds and might not be sufficient when fetching run results
+of larger circuits via slow network connections.
 
 On Linux:
 
@@ -200,15 +223,19 @@ On Windows:
 
   set IQM_CLIENT_REQUESTS_TIMEOUT=120
 
-Once set, this environment variable will control network request timeouts for IQM Client methods ``abort_job``, ``get_quantum_architecture``, ``get_run``, and ``get_run_status``.
+Once set, this environment variable will control network request timeouts for :class:`.IQMClient` methods
+``abort_job``, ``get_quantum_architecture``, ``get_run``, and ``get_run_status``.
 
-Set ``IQM_CLIENT_SECONDS_BETWEEN_CALLS`` to control the polling frequency when waiting for compilation and run results with IQM Client methods ``wait_for_compilation`` and ``wait_for_results``. The default value is set to 1 second.
+Set :envvar:`IQM_CLIENT_SECONDS_BETWEEN_CALLS` to control the polling frequency when waiting for
+compilation and run results with the :meth:`.IQMClient.wait_for_compilation` and
+:meth:`.IQMClient.wait_for_results` methods. The default value is set to 1 second.
 
-Set ``IQM_CLIENT_DEBUG=1`` to print the run request when it is submitted for execution in
+Set :envvar:`IQM_CLIENT_DEBUG=1` to print the run request when it is submitted for execution in
 :meth:`.IQMClient.submit_circuits` or :meth:`.IQMClient.submit_run_request`. To inspect the run request without sending
 it for execution, use :meth:`.IQMClient.create_run_request`.
 
 Integration testing
 -------------------
 
-IQM provides a demo environment to test the integration against a mock quantum computer. If you'd like to request access to that environment, please contact `IQM <info@meetiqm.com>`_.
+IQM provides a demo environment to test the integration against a mock quantum computer. If you'd
+like to request access to that environment, please contact `IQM <info@meetiqm.com>`_.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ show_authors = True
 autodoc_member_order = 'bysource'
 
 # where should signature annotations appear in the docs, function signature or parameter description?
-autodoc_typehints = 'description'
+autodoc_typehints = 'both'
 # autodoc_typehints = 'description' puts the __init__ annotations into its docstring,
 # which we thus have to include in the class documentation.
 autoclass_content = 'class'

--- a/src/iqm/iqm_client/errors.py
+++ b/src/iqm/iqm_client/errors.py
@@ -28,6 +28,10 @@ class CircuitValidationError(RuntimeError):
     """Circuit validation failed."""
 
 
+class CircuitTranspilationError(RuntimeError):
+    """Circuit transpilation failed."""
+
+
 class CircuitExecutionError(RuntimeError):
     """Something went wrong on the server."""
 

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -80,8 +80,8 @@ class IQMClient:
         password: Password to log in to authentication server.
 
     Alternatively, the user authentication related keyword arguments can also be given in
-    environment variables ``IQM_TOKEN``, ``IQM_TOKENS_FILE``, ``IQM_AUTH_SERVER``,
-    ``IQM_AUTH_USERNAME`` and ``IQM_AUTH_PASSWORD``. All parameters must be given either
+    environment variables :envvar:`IQM_TOKEN`, :envvar:`IQM_TOKENS_FILE`, :envvar:`IQM_AUTH_SERVER`,
+    :envvar:`IQM_AUTH_USERNAME` and :envvar:`IQM_AUTH_PASSWORD`. All parameters must be given either
     as keyword arguments or as environment variables. Same combination restrictions apply
     for values given as environment variables as for keyword arguments.
     """

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -455,9 +455,6 @@ class IQMClient:
         # Qubits whose states are currently moved to a resonator
         moved_qubits: set[str] = set()
 
-        if qubit_mapping:
-            reverse_mapping = {phys: log for log, phys in qubit_mapping.items()}
-
         for inst in circuit.instructions:
             if inst.name == 'move':
                 qubit, resonator = inst.qubits

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -149,15 +149,15 @@ class IQMClient:
         """Submits a batch of quantum circuits for execution on a quantum computer.
 
         Args:
-            circuits: list of circuits to be executed
+            circuits: Circuits to be executed.
             qubit_mapping: Mapping of logical qubit names to physical qubit names.
                 Can be set to ``None`` if all ``circuits`` already use physical qubit names.
                 Note that the ``qubit_mapping`` is used for all ``circuits``.
             custom_settings: Custom settings to override default settings and calibration data.
                 Note: This field should always be ``None`` in normal use.
             calibration_set_id: ID of the calibration set to use, or ``None`` to use the latest one
-            shots: number of times ``circuits`` are executed, value must be greater than zero
-            options: Various discrete options for compiling quantum circuits to pulse schedules.
+            shots: Number of times ``circuits`` are executed. Must be greater than zero
+            options: Various discrete options for compiling quantum circuits to instruction schedules.
         Returns:
             ID for the created job. This ID is needed to query the job status and the execution results.
         """
@@ -190,19 +190,15 @@ class IQMClient:
         submitting it for execution.
 
         Args:
-            circuits: list of circuits to be executed
+            circuits: Circuits to be executed.
             qubit_mapping: Mapping of logical qubit names to physical qubit names.
                 Can be set to ``None`` if all ``circuits`` already use physical qubit names.
                 Note that the ``qubit_mapping`` is used for all ``circuits``.
             custom_settings: Custom settings to override default settings and calibration data.
                 Note: This field should always be ``None`` in normal use.
             calibration_set_id: ID of the calibration set to use, or ``None`` to use the latest one
-            shots: number of times ``circuits`` are executed, value must be greater than zero
-            max_circuit_duration_over_t2: Circuits are disqualified on the server if they are longer than this ratio
-                of the T2 time of the qubits. Setting this value to ``0.0`` turns off circuit duration checking.
-                The default value ``None`` instructs server to use server's default value in the checking.
-            heralding_mode: Heralding mode to use during the execution.
-
+            shots: Number of times ``circuits`` are executed. Must be greater than zero.
+            options: Various discrete options for compiling quantum circuits to instruction schedules.
         Returns:
             RunRequest that would be submitted by equivalent call to :meth:`submit_circuits`.
         """
@@ -240,14 +236,13 @@ class IQMClient:
             move_gate_frame_tracking_mode=options.move_gate_frame_tracking,
         )
 
-    def submit_run_request(self, run_request: RunRequest):
+    def submit_run_request(self, run_request: RunRequest) -> UUID:
         """Submits a run request for execution on a quantum computer.
 
         This is called inside :meth:`submit_circuits` and does not need to be called separately in normal usage.
 
         Args:
             run_request: the run request to be submitted for execution.
-
         Returns:
             ID for the created job. This ID is needed to query the job status and the execution results.
         """
@@ -294,18 +289,18 @@ class IQMClient:
         architecture: QuantumArchitectureSpecification,
         circuits: CircuitBatch,
         qubit_mapping: Optional[dict[str, str]] = None,
-    ):
+    ) -> None:
         """Validates the given qubit mapping, if defined.
 
         Args:
-          architecture: the quantum architecture to check against
-          circuits: list of circuits to be checked
+          architecture: Quantum architecture to check against.
+          circuits: Circuits to be checked.
           qubit_mapping: Mapping of logical qubit names to physical qubit names.
               Can be set to ``None`` if all ``circuits`` already use physical qubit names.
               Note that the ``qubit_mapping`` is used for all ``circuits``.
 
         Raises:
-            CircuitExecutionError: IQM server specific exceptions
+            CircuitExecutionError: IQM server specific exceptions.
         """
         if qubit_mapping is None:
             return
@@ -335,19 +330,18 @@ class IQMClient:
         circuits: CircuitBatch,
         qubit_mapping: Optional[dict[str, str]] = None,
         validate_moves: MoveGateValidationMode = MoveGateValidationMode.STRICT,
-    ):
-        """Validates that the instructions target correct qubits in the given circuits.
+    ) -> None:
+        """Raises an error if the given circuits are not valid in the given architecture.
 
         Args:
-            architecture: the quantum architecture to check against
-            circuits: list of circuits to be checked
+            architecture: Quantum architecture to check against.
+            circuits: Circuits to be checked.
             qubit_mapping: Mapping of logical qubit names to physical qubit names.
                 Can be set to ``None`` if all ``circuits`` already use physical qubit names.
                 Note that the ``qubit_mapping`` is used for all ``circuits``.
-            validate_moves: Option for bypassing full or partial MOVE gate validation as described in
-                :class:`MoveGateValidationMode`.
+            validate_moves: Option for bypassing full or partial MOVE gate validation.
         Raises:
-            CircuitExecutionError: IQM server specific exceptions
+            CircuitExecutionError: IQM server specific exceptions.
         """
         for circuit in circuits:
             for instr in circuit.instructions:
@@ -359,18 +353,17 @@ class IQMClient:
         architecture: QuantumArchitectureSpecification,
         instruction: Instruction,
         qubit_mapping: Optional[dict[str, str]] = None,
-    ):
-        """Validates that the instruction targets correct qubits in the given architecture.
+    ) -> None:
+        """Raises an error if the given instruction is not valid in the given architecture.
 
         Args:
-          architecture: the quantum architecture to check against
-          instruction: the instruction to check
+          architecture: Quantum architecture to check against.
+          instruction: Instruction to check.
           qubit_mapping: Mapping of logical qubit names to physical qubit names.
               Can be set to ``None`` if all ``circuits`` already use physical qubit names.
               Note that the ``qubit_mapping`` is used for all ``circuits``.
-
         Raises:
-            CircuitExecutionError: IQM server specific exceptions
+            CircuitExecutionError: IQM server specific exceptions.
         """
         if instruction.name not in architecture.operations:
             raise ValueError(f"Instruction '{instruction.name}' is not supported by the quantum architecture.")
@@ -411,7 +404,7 @@ class IQMClient:
         qubit_mapping: Optional[dict[str, str]] = None,
         validate_moves: MoveGateValidationMode = MoveGateValidationMode.STRICT,
     ) -> None:
-        """Validates that the MOVE gates in the circuit are not exciting the resonator.
+        """Raises an error if the MOVE gates in the circuit are not valid in the given architecture.
 
         Args:
             architecture: Quantum architecture to check against.
@@ -420,7 +413,7 @@ class IQMClient:
                 Can be set to ``None`` if the ``circuit`` already uses physical qubit names.
             validate_moves: Option for bypassing full or partial MOVE gate validation.
         Raises:
-            CircuitExecutionError: ``circuit`` fails the validation
+            CircuitExecutionError: ``circuit`` fails the validation.
         """
         # pylint: disable=too-many-branches
         if validate_moves == MoveGateValidationMode.NONE:

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -343,9 +343,16 @@ class IQMClient:
         Raises:
             CircuitValidationError: There was something wrong with ``circuits``.
         """
-        for circuit in circuits:
+        for index, circuit in enumerate(circuits):
+            measurement_keys: set[str] = set()
             for instr in circuit.instructions:
                 IQMClient._validate_instruction(architecture, instr, qubit_mapping)
+                # check measurement key uniqueness
+                if instr.name in {'measure', 'measurement'}:
+                    key = instr.args['key']
+                    if key in measurement_keys:
+                        raise CircuitValidationError(f'Circuit {index}: {instr!r} has a non-unique measurement key.')
+                    measurement_keys.add(key)
             IQMClient._validate_circuit_moves(architecture, circuit, qubit_mapping, validate_moves=validate_moves)
 
     @staticmethod

--- a/src/iqm/iqm_client/models.py
+++ b/src/iqm/iqm_client/models.py
@@ -132,8 +132,8 @@ class Instruction(BaseModel):
 
     Measurement in the computational (Z) basis. The measurement results are the output of the circuit.
     Takes one string argument, ``key``, denoting the measurement key the results are labeled with.
-    All the measurement keys in a circuit must be unique. Each qubit may only be measured once.
-    The measurement must be the last operation on each qubit, i.e. it cannot be followed by gates.
+    All the measurement keys in a circuit must be unique. Each qubit may be measured multiple times,
+    i.e. mid-circuit measurements are allowed.
 
     .. code-block:: python
         :caption: Example

--- a/src/iqm/iqm_client/models.py
+++ b/src/iqm/iqm_client/models.py
@@ -111,8 +111,9 @@ class Instruction(BaseModel):
     measure          >= 1        ``key: str``                           Measurement in the Z basis.
     prx              1           ``angle_t: float``, ``phase_t: float`` Phased x-rotation gate.
     cz               2                                                  Controlled-Z gate.
+    move             2                                                  Moves a qubit state between a qubit and a
+                                                                        computational resonator.
     barrier          >= 1                                               Execution barrier.
-    move             2                                                  Moves 1 state between resonator and qubit.
     ================ =========== ====================================== ===========
 
     For each Instruction you may also optionally specify :attr:`~Instruction.implementation`,
@@ -124,8 +125,8 @@ class Instruction(BaseModel):
 
         The following instruction names are deprecated, but supported for backwards compatibility for now:
 
-    * ``phased_rx`` ↦ ``prx``
-    * ``measurement`` ↦ ``measure``
+        * ``phased_rx`` ↦ ``prx``
+        * ``measurement`` ↦ ``measure``
 
     Measure
     -------
@@ -197,6 +198,8 @@ class Instruction(BaseModel):
 
         Instruction(name='move', qubits=('alice', 'resonator'), args={})
 
+    .. note:: MOVE is only available in quantum computers with the IQM Star architecture.
+
     Barrier
     -------
 
@@ -212,11 +215,11 @@ class Instruction(BaseModel):
 
         Instruction(name='barrier', qubits=('alice', 'bob'), args={})
 
-    *Note*
-    1-qubit barriers will not have any effect on circuit's compilation and execution. Higher layers
-    that sit on top of IQM Client can make actual use of 1-qubit barriers (e.g. during circuit optimization),
-    therefore having them is allowed.
+    .. note::
 
+       One-qubit barriers will not have any effect on circuit's compilation and execution. Higher layers
+       that sit on top of IQM Client can make actual use of one-qubit barriers (e.g. during circuit optimization),
+       therefore having them is allowed.
     """
 
     name: str = Field(..., examples=['measure'])

--- a/src/iqm/iqm_client/models.py
+++ b/src/iqm/iqm_client/models.py
@@ -563,9 +563,11 @@ class CircuitCompilationOptions:
     """Various discrete options for quantum circuit compilation to pulse schedule."""
 
     max_circuit_duration_over_t2: Optional[float] = None
-    """Circuits are disqualified on the server if they are longer than this ratio
-        of the T2 time of the qubits. Setting this value to ``0.0`` turns off circuit duration checking.
-        The default value ``None`` instructs server to use server's default value in the checking."""
+    """Server-side circuit disqualification threshold.
+    The job is rejected on the server if any circuit in it is estimated to take longer than
+    the shortest T2 time of any qubit used in the circuit, multiplied by this value.
+    Setting this value to ``0.0`` turns off circuit duration checking.
+    ``None`` tells the server to use its default value in the check."""
     heralding_mode: HeraldingMode = HeraldingMode.NONE
     """Heralding mode to use during the execution."""
     move_gate_validation: MoveGateValidationMode = MoveGateValidationMode.STRICT

--- a/src/iqm/iqm_client/transpile.py
+++ b/src/iqm/iqm_client/transpile.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 IQM client developers
+# Copyright 2021-2024 IQM client developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""
-Collection of transpile functions needed for transpiling to specific devices
+"""
+Collection of transpilation functions needed for transpiling to specific devices.
 """
 from enum import Enum
 from typing import Any, Iterable, Optional
@@ -32,21 +32,21 @@ class ExistingMoveHandlingOptions(str, Enum):
     """Transpile options for handling of existing MOVE instructions."""
 
     KEEP = 'keep'
-    """Transpiler will keep the move instructions as specified checking if they are correct, adding more as needed."""
+    """Transpiler will keep the MOVE instructions as specified checking if they are correct, adding more as needed."""
     REMOVE = 'remove'
     """Transpiler will remove the instructions and add new ones."""
     TRUST = 'trust'
-    """Transpiler will keep the move instructions without checking if they are correct, and add more as needed."""
+    """Transpiler will keep the MOVE instructions without checking if they are correct, and add more as needed."""
 
 
 class ResonatorStateTracker:
     """Class for tracking the location of the |0> state of the resonators on the quantum computer as they are moved
     with the MOVE gates because the MOVE gate is not defined when acting on a |11> state. This is equivalent to tracking
-    the which qubit state has been MOVEd into which resonator.
+    the which qubit state has been moved into which resonator.
 
     Args:
-        available_moves: A dictionary describing between which qubits a move gate is
-        available, for each resonator, i.e. `available_moves[resonator] = [qubit]`
+        available_moves: A dictionary describing between which qubits a MOVE gate is
+            available, for each resonator, i.e. ``available_moves[resonator] = [qubit]``
     """
 
     move_gate = 'move'
@@ -71,8 +71,9 @@ class ResonatorStateTracker:
 
     @staticmethod
     def from_circuit(circuit: Circuit) -> 'ResonatorStateTracker':
-        """Constructor to make the ResonatorStateTracker from a circuit. It infers the resonator connectivity from the
-        move gates in the circuit.
+        """Constructor to make the ResonatorStateTracker from a circuit.
+
+        Infers the resonator connectivity from the MOVE gates in the circuit.
 
         Args:
             circuit: The circuit to track the resonator state on.
@@ -81,8 +82,9 @@ class ResonatorStateTracker:
 
     @staticmethod
     def from_instructions(instructions: Iterable[Instruction]) -> 'ResonatorStateTracker':
-        """Constructor to make the ResonatorStateTracker from a sequence of instructions. It infers the resonator
-        connectivity from the move instructions.
+        """Constructor to make the ResonatorStateTracker from a sequence of instructions.
+
+        Infers the resonator connectivity from the MOVE gates.
 
         Args:
             instructions: The instructions to track the resonator state on.
@@ -101,11 +103,11 @@ class ResonatorStateTracker:
 
     @property
     def supports_move(self) -> bool:
-        """Bool whether any move gate is allowed."""
+        """Bool whether any MOVE gate is allowed."""
         return bool(self.available_moves)
 
     def apply_move(self, qubit: str, resonator: str) -> None:
-        """Apply the logical changes of the resonator state location when a move gate between qubit and resonator is
+        """Apply the logical changes of the resonator state location when a MOVE gate between qubit and resonator is
         applied.
 
         Args:
@@ -113,9 +115,9 @@ class ResonatorStateTracker:
             resonator: The moved resonator.
 
         Raises:
-            CircuitTranspilationError: When the move is not allowed, either because the resonator does not exist, the move
-            gate is not valid between this qubit-resonator pair, or the resonator state is currently in a different
-            qubit register.
+            CircuitTranspilationError: MOVE is not allowed, either because the resonator does not exist,
+                the MOVE gate is not available between this qubit-resonator pair, or the resonator state
+                is currently in a different qubit register.
         """
         if (
             resonator in self.resonators
@@ -133,18 +135,17 @@ class ResonatorStateTracker:
         apply_move: Optional[bool] = True,
         alt_qubit_names: Optional[dict[str, str]] = None,
     ) -> Iterable[Instruction]:
-        """Create the move instructions needed to move the given resonator state into the resonator if needed and then
+        """Create the MOVE instructions needed to move the given resonator state into the resonator if needed and then
         move resonator state to the given qubit.
 
         Args:
             qubit: The qubit
             resonator: The resonator
             apply_move: Whether the moves should be applied to the resonator tracking state.
-            Defaults to True.
             alt_qubit_names: Mapping of logical qubit names to physical qubit names.
 
         Yields:
-            The one or two move instructions needed.
+            The one or two MOVE instructions needed.
         """
         if self.res_qb_map[resonator] not in [qubit, resonator]:
             other = self.res_qb_map[resonator]
@@ -163,13 +164,11 @@ class ResonatorStateTracker:
         apply_move: Optional[bool] = True,
         alt_qubit_names: Optional[dict[str, str]] = None,
     ) -> list[Instruction]:
-        """Creates the move instructions needed to move all resonator states to their original state.
+        """Creates the MOVE instructions needed to move all resonator states to their original state.
 
         Args:
-            resonators: The set of resonators to reset, if None, all resonators will
-            be reset. Defaults to None.
+            resonators: The set of resonators to reset, if None, all resonators will be reset.
             apply_move: Whether the moves should be applied to the resonator tracking state.
-            Defaults to True.
 
         Returns:
             The instructions needed to move all qubit states out of the resonators.
@@ -185,7 +184,7 @@ class ResonatorStateTracker:
         """Generates a dictionary with which resonators a qubit can be moved to, for each qubit.
 
         Args:
-            qubits: The qubits to check which move gates are available.
+            qubits: The qubits to check which MOVE gates are available.
 
         Returns:
             The dict that maps each qubit to a list of resonators.
@@ -231,8 +230,9 @@ class ResonatorStateTracker:
         return resonator_candidates
 
     def _score_choice_heuristic(self, args: tuple[str, str, list[list[str]]]) -> int:
-        """A simple look ahead heuristic for choosing which qubit to move where. Counts the number of CZ gates until the
-        qubit needs to be moved out.
+        """A simple look ahead heuristic for choosing which qubit to move where.
+
+        Counts the number of CZ gates until the qubit needs to be moved out.
 
         Args:
             args: resonator, qubit, instructions.
@@ -267,20 +267,21 @@ def transpile_insert_moves(
     existing_moves: Optional[ExistingMoveHandlingOptions] = None,
     qubit_mapping: Optional[dict[str, str]] = None,
 ) -> Circuit:
-    """Transpile method that inserts moves to the circuit according to a given architecture specification.
-    The function does nothing if the given architecture specification does not support move Instructions.
+    """Inserts MOVEs to the circuit according to a given architecture specification.
+
+    The function does nothing if the given architecture specification does not support MOVE gates.
     Note that this method assumes that the circuit is already transpiled to a coupling map/architecture where the
     resonator has been abstracted away, i.e. the edges of the coupling map that contain resonators are replaced by
     edges between the other qubit and all qubits that can be moved to that resonator.
 
     Args:
-        circuit: The circuit to add Move instructions to.
+        circuit: The circuit to add MOVE instructions to.
         arch: Restrictions of the target device
-        existing_moves: Specifies how to deal with existing move instruction,
+        existing_moves: Specifies how to deal with existing MOVE instruction,
             If None, the function will use ExistingMoveHandlingOptions.REMOVE with a user warning if there are move
-            instructions in the circuit. Defaults to None.
-          qubit_mapping: Mapping of logical qubit names to physical qubit names.
-              Can be set to ``None`` if all ``circuits`` already use physical qubit names.
+            instructions in the circuit.
+        qubit_mapping: Mapping of logical qubit names to physical qubit names.
+            Can be set to ``None`` if all ``circuits`` already use physical qubit names.
     """
     res_status = ResonatorStateTracker.from_quantum_architecture_specification(arch)
     if not qubit_mapping:
@@ -291,7 +292,7 @@ def transpile_insert_moves(
     existing_moves_in_circuit = [i for i in circuit.instructions if i.name == res_status.move_gate]
 
     if existing_moves is None and len(existing_moves_in_circuit) > 0:
-        warnings.warn('Circuit already contains Move Instructions, removing them before transpiling.')
+        warnings.warn('Circuit already contains MOVE instructions, removing them before transpiling.')
         existing_moves = ExistingMoveHandlingOptions.REMOVE
 
     if not res_status.supports_move:
@@ -299,7 +300,7 @@ def transpile_insert_moves(
             return circuit
         if existing_moves == ExistingMoveHandlingOptions.REMOVE:
             return transpile_remove_moves(circuit)
-        raise ValueError('Circuit contains Move instructions, but device does not support them')
+        raise ValueError('Circuit contains MOVE instructions, but device does not support them')
 
     if existing_moves is None or existing_moves == ExistingMoveHandlingOptions.REMOVE:
         circuit = transpile_remove_moves(circuit)
@@ -324,7 +325,7 @@ def _transpile_insert_moves(
     arch: QuantumArchitectureSpecification,
     qubit_mapping: dict[str, str],
 ) -> list[Instruction]:
-    """Helper function for transpile_insert_moves that inserts MOVE gates into a list of instructions and changes the
+    """Helper function for :func:`transpile_insert_moves` that inserts MOVE gates into a list of instructions and changes the
     existing instructions as needed.
 
     Args:
@@ -336,7 +337,7 @@ def _transpile_insert_moves(
 
     Raises:
         CircuitTranspilationError: Raised when the circuit contains invalid gates that cannot be transpiled using this
-        method.
+            method.
 
     Returns:
         The transpiled list of instructions.
@@ -403,16 +404,16 @@ def _transpile_insert_moves(
 
 
 def transpile_remove_moves(circuit: Circuit) -> Circuit:
-    """Transpile method that removes move gates from a circuit.
+    """Removes MOVE gates from a circuit.
 
-    The method assumes that these move gates are moving the resonator state in and out the resonator register to
+    The method assumes that these MOVE gates are moving the resonator state in and out the resonator register to
     reconstruct the CZ gates. If this is not the case, the semantic equivalence cannot be guaranteed.
 
     Args:
-        circuit: The circuit from which the move gates need to be removed.
+        circuit: The circuit from which the MOVE gates need to be removed.
 
     Returns:
-        The circuit with the move gates removed and the targets for all other gates updated accordingly.
+        The circuit with the MOVE gates removed and the targets for all other gates updated accordingly.
     """
     res_status = ResonatorStateTracker.from_circuit(circuit)
     new_instructions = []

--- a/src/iqm/iqm_client/transpile.py
+++ b/src/iqm/iqm_client/transpile.py
@@ -325,8 +325,9 @@ def _transpile_insert_moves(
     arch: QuantumArchitectureSpecification,
     qubit_mapping: dict[str, str],
 ) -> list[Instruction]:
-    """Helper function for :func:`transpile_insert_moves` that inserts MOVE gates into a list of instructions and changes the
-    existing instructions as needed.
+    """Inserts MOVE gates into a list of instructions and changes the existing instructions as needed.
+
+    Helper function for :func:`transpile_insert_moves`.
 
     Args:
         instructions: The instructions in the circuit.

--- a/src/iqm/iqm_client/transpile.py
+++ b/src/iqm/iqm_client/transpile.py
@@ -40,8 +40,8 @@ class ExistingMoveHandlingOptions(str, Enum):
 
 
 class ResonatorStateTracker:
-    """Class for tracking the location of the |0> state of the resonators on the quantum computer as they are moved
-    with the MOVE gates because the MOVE gate is not defined when acting on a |11> state. This is equivalent to tracking
+    r"""Class for tracking the location of the :math:`|0\rangle` state of the resonators on the quantum computer as they are moved
+    with the MOVE gates because the MOVE gate is not defined when acting on a :math:`|11\rangle` state. This is equivalent to tracking
     the which qubit state has been moved into which resonator.
 
     Args:

--- a/src/iqm/iqm_client/transpile.py
+++ b/src/iqm/iqm_client/transpile.py
@@ -40,8 +40,9 @@ class ExistingMoveHandlingOptions(str, Enum):
 
 
 class ResonatorStateTracker:
-    r"""Class for tracking the location of the :math:`|0\rangle` state of the resonators on the quantum computer as they are moved
-    with the MOVE gates because the MOVE gate is not defined when acting on a :math:`|11\rangle` state. This is equivalent to tracking
+    r"""Class for tracking the location of the :math:`|0\rangle` state of the resonators on the
+    quantum computer as they are moved with the MOVE gates because the MOVE gate is not defined
+    when acting on a :math:`|11\rangle` state. This is equivalent to tracking
     the which qubit state has been moved into which resonator.
 
     Args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,11 @@ def sample_resonator_circuit():
             args={'phase_t': 0.3, 'angle_t': -0.2},
         ),
         Instruction(
+            name='move',
+            qubits=('QB3', 'COMP_R'),
+            args={},
+        ),
+        Instruction(
             name='cz',
             qubits=('QB1', 'COMP_R'),
             args={},
@@ -178,8 +183,40 @@ def sample_resonator_circuit():
             qubits=('QB2', 'COMP_R'),
             args={},
         ),
+        Instruction(
+            name='move',
+            qubits=('QB3', 'COMP_R'),
+            args={},
+        ),
     )
     return Circuit(name='COMP_R circuit', instructions=instructions)
+
+
+@pytest.fixture
+def move_circuit_with_prx_in_the_sandwich():
+    instructions = (
+        Instruction(
+            name='prx',
+            qubits=('QB1',),
+            args={'phase_t': 0.3, 'angle_t': -0.2},
+        ),
+        Instruction(
+            name='move',
+            qubits=('QB3', 'COMP_R'),
+            args={},
+        ),
+        Instruction(
+            name='prx',
+            qubits=('QB3',),
+            args={'phase_t': 0.3, 'angle_t': -0.2},
+        ),
+        Instruction(
+            name='move',
+            qubits=('QB3', 'COMP_R'),
+            args={},
+        ),
+    )
+    return Circuit(name='COMP_R circuit with PRX in the sandwich', instructions=instructions)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,65 +161,6 @@ def create_sample_circuit(qubits: list[str], metadata) -> Circuit:
 
 
 @pytest.fixture
-def sample_resonator_circuit():
-    instructions = (
-        Instruction(
-            name='prx',
-            qubits=('QB1',),
-            args={'phase_t': 0.3, 'angle_t': -0.2},
-        ),
-        Instruction(
-            name='move',
-            qubits=('QB3', 'COMP_R'),
-            args={},
-        ),
-        Instruction(
-            name='cz',
-            qubits=('QB1', 'COMP_R'),
-            args={},
-        ),
-        Instruction(
-            name='cz',
-            qubits=('QB2', 'COMP_R'),
-            args={},
-        ),
-        Instruction(
-            name='move',
-            qubits=('QB3', 'COMP_R'),
-            args={},
-        ),
-    )
-    return Circuit(name='COMP_R circuit', instructions=instructions)
-
-
-@pytest.fixture
-def move_circuit_with_prx_in_the_sandwich():
-    instructions = (
-        Instruction(
-            name='prx',
-            qubits=('QB1',),
-            args={'phase_t': 0.3, 'angle_t': -0.2},
-        ),
-        Instruction(
-            name='move',
-            qubits=('QB3', 'COMP_R'),
-            args={},
-        ),
-        Instruction(
-            name='prx',
-            qubits=('QB3',),
-            args={'phase_t': 0.3, 'angle_t': -0.2},
-        ),
-        Instruction(
-            name='move',
-            qubits=('QB3', 'COMP_R'),
-            args={},
-        ),
-    )
-    return Circuit(name='COMP_R circuit with PRX in the sandwich', instructions=instructions)
-
-
-@pytest.fixture
 def sample_circuit_with_raw_instructions(sample_circuit_metadata):
     """
     A sample circuit with instructions defined by dicts for testing if
@@ -502,11 +443,14 @@ def sample_move_architecture():
     return {
         'quantum_architecture': {
             'name': 'hercules',
-            'qubits': ['COMP_R', 'QB1', 'QB2', 'QB3'],
+            'qubits': ['COMP_R', 'QB1', 'QB2', 'QB3', 'COMP_R2'],
             'qubit_connectivity': [
                 ['QB1', 'COMP_R'],
                 ['QB2', 'COMP_R'],
                 ['QB3', 'COMP_R'],
+                ['QB1', 'COMP_R2'],
+                ['QB2', 'COMP_R2'],
+                ['QB3', 'COMP_R2'],
             ],
             'operations': {
                 'prx': [['QB1'], ['QB2'], ['QB3']],

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -22,11 +22,13 @@ import requests
 from requests import HTTPError
 
 from iqm.iqm_client import (
+    Circuit,
     CircuitCompilationOptions,
     CircuitExecutionError,
     CircuitValidationError,
     ClientConfigurationError,
     HeraldingMode,
+    Instruction,
     IQMClient,
     JobAbortionError,
     QuantumArchitectureSpecification,
@@ -36,6 +38,65 @@ from iqm.iqm_client import (
     validate_circuit,
 )
 from tests.conftest import MockJsonResponse, get_jobs_args, post_jobs_args, submit_circuits_args
+
+
+@pytest.fixture
+def move_circuit():
+    instructions = (
+        Instruction(
+            name='prx',
+            qubits=('QB1',),
+            args={'phase_t': 0.3, 'angle_t': -0.2},
+        ),
+        Instruction(
+            name='move',
+            qubits=('QB3', 'COMP_R'),
+            args={},
+        ),
+        Instruction(
+            name='cz',
+            qubits=('QB1', 'COMP_R'),
+            args={},
+        ),
+        Instruction(
+            name='cz',
+            qubits=('QB2', 'COMP_R'),
+            args={},
+        ),
+        Instruction(
+            name='move',
+            qubits=('QB3', 'COMP_R'),
+            args={},
+        ),
+    )
+    return Circuit(name='COMP_R circuit', instructions=instructions)
+
+
+@pytest.fixture
+def move_circuit_with_prx_in_the_sandwich():
+    instructions = (
+        Instruction(
+            name='prx',
+            qubits=('QB1',),
+            args={'phase_t': 0.3, 'angle_t': -0.2},
+        ),
+        Instruction(
+            name='move',
+            qubits=('QB3', 'COMP_R'),
+            args={},
+        ),
+        Instruction(
+            name='prx',
+            qubits=('QB3',),
+            args={'phase_t': 0.3, 'angle_t': -0.2},
+        ),
+        Instruction(
+            name='move',
+            qubits=('QB3', 'COMP_R'),
+            args={},
+        ),
+    )
+    return Circuit(name='COMP_R circuit with PRX in the sandwich', instructions=instructions)
 
 
 def test_serialize_qubit_mapping():
@@ -772,7 +833,7 @@ def test_create_and_submit_run_request(
         ]
         for success_result, sample_circuit in zip(
             ['quantum_architecture_success', 'move_architecture_success', 'move_architecture_success'],
-            ['sample_circuit', 'sample_resonator_circuit', 'move_circuit_with_prx_in_the_sandwich'],
+            ['sample_circuit', 'move_circuit', 'move_circuit_with_prx_in_the_sandwich'],
         )
     ],
 )

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -492,6 +492,7 @@ class TestResonatorStateTracker:
         status = ResonatorStateTracker.from_quantum_architecture_specification(arch)
         assert status.available_resonators_to_move(qubits) == {
             'COMP_R': [],
+            'COMP_R2': [],
             'QB1': [],
             'QB2': [],
             'QB3': ['COMP_R'],
@@ -522,4 +523,4 @@ class TestResonatorStateTracker:
         arch: QuantumArchitectureSpecification = QuantumArchitecture(**sample_move_architecture).quantum_architecture
         status = ResonatorStateTracker.from_quantum_architecture_specification(arch)
         status.apply_move('QB3', 'COMP_R')
-        assert status.update_qubits_in_resonator(qubits) == ['QB3', 'QB1', 'QB2', 'QB3']
+        assert status.update_qubits_in_resonator(qubits) == ['QB3', 'QB1', 'QB2', 'QB3', 'COMP_R2']

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -5,7 +5,6 @@ import pytest
 from iqm.iqm_client import (
     Circuit,
     CircuitTranspilationError,
-    CircuitValidationError,
     ExistingMoveHandlingOptions,
     Instruction,
     IQMClient,

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -4,7 +4,8 @@ import pytest
 
 from iqm.iqm_client import (
     Circuit,
-    CircuitExecutionError,
+    CircuitTranspilationError,
+    CircuitValidationError,
     ExistingMoveHandlingOptions,
     Instruction,
     IQMClient,
@@ -238,7 +239,7 @@ class TestNaiveMoveTranspiler:
             c1 = self.insert(self.simple_circuit, handling_option)
             self.assert_valid_circuit(c1)
             assert self.check_equiv_without_moves(c1, self.simple_circuit)
-            with pytest.raises(CircuitExecutionError):
+            with pytest.raises(CircuitTranspilationError):
                 self.insert(sample_circuit, handling_option)  # untranspiled circuit
 
     def test_keep(self):
@@ -248,10 +249,10 @@ class TestNaiveMoveTranspiler:
         self.assert_valid_circuit(c1)
         assert self.check_moves_in_circuit(c1, moves)
 
-        with pytest.raises(CircuitExecutionError):
+        with pytest.raises(CircuitTranspilationError):
             self.insert(self.unsafe_circuit, ExistingMoveHandlingOptions.KEEP)
 
-        with pytest.raises(CircuitExecutionError):
+        with pytest.raises(CircuitTranspilationError):
             self.insert(self.ambiguous_circuit, ExistingMoveHandlingOptions.KEEP)
 
     def test_remove(self):
@@ -305,7 +306,7 @@ class TestNaiveMoveTranspiler:
                 Instruction(name='cz', qubits=('QB1', 'QB3'), args={}),
             ),
         )
-        with pytest.raises(CircuitExecutionError):
+        with pytest.raises(CircuitTranspilationError):
             transpiled_circuit = transpile_insert_moves(circuit, arch)
 
         # Add the necessary CZ gates to make it a good architecture.
@@ -332,7 +333,7 @@ class TestNaiveMoveTranspiler:
                 ),
             ),
         )
-        with pytest.raises(CircuitExecutionError):
+        with pytest.raises(CircuitTranspilationError):
             self.insert(c, qb_map={'QB5': 'QB5'})
 
     def test_unavailable_cz(self):
@@ -417,7 +418,7 @@ class TestResonatorStateTracker:
         arch = QuantumArchitecture(**sample_move_architecture).quantum_architecture
         no_move_status = ResonatorStateTracker.from_quantum_architecture_specification(no_move_arch)
         assert not no_move_status.supports_move
-        with pytest.raises(CircuitExecutionError):
+        with pytest.raises(CircuitTranspilationError):
             no_move_status.apply_move('QB1', 'QB2')
         # Check handling of an architecture with resonator
         status = ResonatorStateTracker.from_quantum_architecture_specification(arch)
@@ -426,12 +427,12 @@ class TestResonatorStateTracker:
         assert status.res_qb_map['COMP_R'] == 'QB3'
         status.apply_move('QB3', 'COMP_R')
         assert status.res_qb_map['COMP_R'] == 'COMP_R'
-        with pytest.raises(CircuitExecutionError):
+        with pytest.raises(CircuitTranspilationError):
             status.apply_move('QB1', 'COMP_R')
-        with pytest.raises(CircuitExecutionError):
+        with pytest.raises(CircuitTranspilationError):
             status.apply_move('QB1', 'QB2')
         status.res_qb_map['COMP_R'] = 'QB1'
-        with pytest.raises(CircuitExecutionError):
+        with pytest.raises(CircuitTranspilationError):
             status.apply_move('QB3', 'COMP_R')
 
     def test_create_move_instructions(self, sample_move_architecture: dict[str, Any]):
@@ -509,7 +510,7 @@ class TestResonatorStateTracker:
     def test_choose_move_pair(self, sample_move_architecture: dict[str, Any]):
         arch: QuantumArchitectureSpecification = QuantumArchitecture(**sample_move_architecture).quantum_architecture
         status = ResonatorStateTracker.from_quantum_architecture_specification(arch)
-        with pytest.raises(CircuitExecutionError):
+        with pytest.raises(CircuitTranspilationError):
             status.choose_move_pair(['QB1', 'QB2'], [])
         resonator_candidates = status.choose_move_pair(
             ['QB1', 'QB2', 'QB3'], [['cz', 'QB2', 'QB3'], ['prx', 'QB2'], ['prx', 'QB3']]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,14 @@ import re
 
 import pytest
 
-from iqm.iqm_client import Circuit, CircuitExecutionError, Instruction, IQMClient, QuantumArchitecture
+from iqm.iqm_client import (
+    Circuit,
+    CircuitExecutionError,
+    Instruction,
+    IQMClient,
+    MoveGateValidationMode,
+    QuantumArchitecture,
+)
 
 sample_qb_mapping = {'0': 'COMP_R', '1': 'QB1', '2': 'QB2', '3': 'QB3'}
 reverse_qb_mapping = {value: key for key, value in sample_qb_mapping.items()}
@@ -111,23 +118,49 @@ class TestMoveSafetyValidation:
     cz = Instruction(name='cz', qubits=['QB2', 'COMP_R'], args={})
 
     @staticmethod
-    def make_circuit_and_check(instructions: tuple[Instruction], arch: QuantumArchitecture, qubit_mapping=None):
+    def make_circuit_and_check(
+        instructions: tuple[Instruction],
+        arch: QuantumArchitecture,
+        validate_moves: MoveGateValidationMode,
+        qubit_mapping=None,
+    ):
         circuit = Circuit(name='Move validation circuit', instructions=instructions)
-        IQMClient._validate_circuit_moves(arch.quantum_architecture, circuit, qubit_mapping)
+        IQMClient._validate_circuit_instructions(
+            arch.quantum_architecture, [circuit], qubit_mapping, validate_moves=validate_moves
+        )
 
-    def test_moves_paired(self, sample_move_architecture):
+    @pytest.mark.parametrize('validate_moves', list(MoveGateValidationMode))
+    def test_moves_paired(self, sample_move_architecture, validate_moves):
         arch = QuantumArchitecture(**sample_move_architecture)
         instructions = (TestMoveSafetyValidation.move,)
-        with pytest.raises(CircuitExecutionError):
-            TestMoveSafetyValidation.make_circuit_and_check(instructions, arch)
-        with pytest.raises(CircuitExecutionError):
-            TestMoveSafetyValidation.make_circuit_and_check(
-                (
-                    TestMoveSafetyValidation.move,
-                    Instruction(name='move', qubits=['QB2', 'COMP_R'], args={}),
-                ),
-                arch,
+        # Single MOVE is not allowed
+        if validate_moves != MoveGateValidationMode.NONE:
+            with pytest.raises(CircuitExecutionError):
+                TestMoveSafetyValidation.make_circuit_and_check(instructions, arch, validate_moves)
+        else:
+            TestMoveSafetyValidation.make_circuit_and_check(instructions, arch, validate_moves)
+
+        # MOVEs must be paired
+        invalid_sandwich_circuit = Circuit(
+            name='Move validation circuit',
+            instructions=(
+                TestMoveSafetyValidation.move,
+                Instruction(name='move', qubits=['QB2', 'COMP_R'], args={}),
+            ),  # Invalid MOVE gate, but only checking MOVE validation here
+        )
+        if validate_moves != MoveGateValidationMode.NONE:
+            with pytest.raises(CircuitExecutionError):
+                IQMClient._validate_circuit_moves(
+                    arch.quantum_architecture, invalid_sandwich_circuit, validate_moves=validate_moves
+                )
+        else:
+            IQMClient._validate_circuit_moves(
+                arch.quantum_architecture, invalid_sandwich_circuit, validate_moves=validate_moves
             )
+        # Normal use of MOVE sandwich is fine.
+        TestMoveSafetyValidation.make_circuit_and_check(instructions * 2, arch, validate_moves)
+
+        # Resonator is the second argument - Regardless of validation mode, this is not allowed
         with pytest.raises(CircuitExecutionError):
             TestMoveSafetyValidation.make_circuit_and_check(
                 (
@@ -135,15 +168,39 @@ class TestMoveSafetyValidation:
                     Instruction(name='move', qubits=['COMP_R', 'QB3'], args={}),
                 ),
                 arch,
+                validate_moves,
             )
-        TestMoveSafetyValidation.make_circuit_and_check(instructions * 2, arch)
-
-    def test_gates_between_moves(self, sample_move_architecture):
-        arch = QuantumArchitecture(**sample_move_architecture)
+        # MOVE needs to have valid loci
         with pytest.raises(CircuitExecutionError):
             TestMoveSafetyValidation.make_circuit_and_check(
-                (TestMoveSafetyValidation.move, TestMoveSafetyValidation.gate, TestMoveSafetyValidation.move), arch
+                (
+                    Instruction(name='move', qubits=['QB1', 'COMP_R'], args={}),
+                    Instruction(name='move', qubits=['QB1', 'COMP_R'], args={}),
+                ),
+                arch,
+                validate_moves,
             )
+
+    @pytest.mark.parametrize('validate_moves', list(MoveGateValidationMode))
+    def test_gates_between_moves(self, sample_move_architecture, validate_moves):
+        arch = QuantumArchitecture(**sample_move_architecture)
+        # PRX is not allowed between moves
+        if validate_moves == MoveGateValidationMode.STRICT:
+            with pytest.raises(CircuitExecutionError):
+                TestMoveSafetyValidation.make_circuit_and_check(
+                    (TestMoveSafetyValidation.move, TestMoveSafetyValidation.gate, TestMoveSafetyValidation.move),
+                    arch,
+                    validate_moves,
+                )
+        elif validate_moves in [MoveGateValidationMode.ALLOW_PRX, MoveGateValidationMode.NONE]:
+            TestMoveSafetyValidation.make_circuit_and_check(
+                (TestMoveSafetyValidation.move, TestMoveSafetyValidation.gate, TestMoveSafetyValidation.move),
+                arch,
+                validate_moves,
+            )
+        else:
+            raise ValueError(f'Unexpected validation mode: {validate_moves}')
+        # CZ is allowed between moves
         TestMoveSafetyValidation.make_circuit_and_check(
             (
                 TestMoveSafetyValidation.gate,
@@ -152,20 +209,25 @@ class TestMoveSafetyValidation:
                 TestMoveSafetyValidation.move,
             ),
             arch,
+            validate_moves,
         )
 
-    def test_device_without_resonator(self, sample_quantum_architecture, sample_circuit):
+    @pytest.mark.parametrize('validate_moves', list(MoveGateValidationMode))
+    def test_device_without_resonator(self, sample_quantum_architecture, sample_circuit, validate_moves):
         arch = QuantumArchitecture(**sample_quantum_architecture)
-        with pytest.raises(CircuitExecutionError):
-            TestMoveSafetyValidation.make_circuit_and_check((TestMoveSafetyValidation.move,), arch)
-        TestMoveSafetyValidation.make_circuit_and_check(sample_circuit.instructions, arch)
+        # Cannot use a MOVE gate on a device that does not support it
+        with pytest.raises(ValueError):
+            TestMoveSafetyValidation.make_circuit_and_check((TestMoveSafetyValidation.move,), arch, validate_moves)
+        # But validation passes if there are no MOVE gates
+        TestMoveSafetyValidation.make_circuit_and_check(sample_circuit.instructions, arch, validate_moves)
 
-    def test_qubit_mapping(self, sample_move_architecture):
+    @pytest.mark.parametrize('validate_moves', list(MoveGateValidationMode))
+    def test_qubit_mapping(self, sample_move_architecture, validate_moves):
         arch = QuantumArchitecture(**sample_move_architecture)
         move = Instruction(name='move', qubits=[reverse_qb_mapping[qb] for qb in ['QB3', 'COMP_R']], args={})
         gate = Instruction(
             name='prx', qubits=[reverse_qb_mapping[qb] for qb in ['QB3']], args={'phase_t': 0.3, 'angle_t': -0.2}
         )
         cz = Instruction(name='cz', qubits=[reverse_qb_mapping[qb] for qb in ['QB2', 'COMP_R']], args={})
-        TestMoveSafetyValidation.make_circuit_and_check((move, move), arch, sample_qb_mapping)
-        TestMoveSafetyValidation.make_circuit_and_check((gate, move, cz, move), arch, sample_qb_mapping)
+        TestMoveSafetyValidation.make_circuit_and_check((move, move), arch, validate_moves, sample_qb_mapping)
+        TestMoveSafetyValidation.make_circuit_and_check((gate, move, cz, move), arch, validate_moves, sample_qb_mapping)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -106,6 +106,50 @@ def test_disallowed_measure_qubits(sample_move_architecture, qubits):
         )
 
 
+def test_measurement_keys_must_be_unique(sample_move_architecture):
+    """
+    Tests that all measure instructions in a circuit must have unique keys.
+    """
+    arch = QuantumArchitecture(**sample_move_architecture)
+    circuit = Circuit(
+        name='Test circuit',
+        instructions=[
+            Instruction(name='measure', qubits=['QB1'], args={'key': 'a'}),
+            Instruction(name='measure', qubits=['QB2'], args={'key': 'a'}),
+        ],
+    )
+    with pytest.raises(CircuitValidationError, match='has a non-unique measurement key'):
+        IQMClient._validate_circuit_instructions(
+            arch.quantum_architecture,
+            [circuit],
+        )
+
+
+def test_same_measurement_key_in_different_circuits(sample_move_architecture):
+    """
+    Tests that the same measurement key can be used in different circuits.
+    """
+    arch = QuantumArchitecture(**sample_move_architecture)
+    circuits = [
+        Circuit(
+            name='Test circuit 1',
+            instructions=[
+                Instruction(name='measure', qubits=['QB1'], args={'key': 'a'}),
+            ],
+        ),
+        Circuit(
+            name='Test circuit 2',
+            instructions=[
+                Instruction(name='measure', qubits=['QB1'], args={'key': 'a'}),
+            ],
+        ),
+    ]
+    IQMClient._validate_circuit_instructions(
+        arch.quantum_architecture,
+        circuits,
+    )
+
+
 @pytest.mark.parametrize(
     'qubits',
     [

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,10 @@ skip_install = True
 changedir = {toxinidir}
 deps =
     black ~= 23.11
+    isort ~= 5.12
 commands =
     black src tests
+    isort src tests
 
 [testenv:docs]
 description =


### PR DESCRIPTION
COMP-1491

- Bugfix: `CircuitCompilationOptions` that turn off MOVE validation were not used in local circuit validation. Improved testing to catch this situation
- Bugfix: MOVE gate validation works with a QPU with more than one resonator.
- Added a note in the changelog marking the CoCoS version that supports the `CircuitCompilationOptions` intruduced in `iqm-client==18.0`, older versions don't raise an error but the option is not supported and will be ignored.
- Docs updated.
- Validate that measurement keys in a circuit are unique.
- Added  `isort` into the tox formatting environment.