### PR TITLE
Remove unnecessary build files when publishing documentation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,8 @@ jobs:
         run: |
           tox -e docs
           touch build/sphinx/html/.nojekyll  # allow underscores in URL path
+          # remove unnecessary build files
+          sudo rm -rf build/sphinx/html/.doctrees
       - name: Publish to gh-pages
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 18.3
+============
+
+* Remove unnecessary build files when publishing documentation. `#133 <https://github.com/iqm-finland/iqm-client/pull/133>`_
+
 Version 18.2
 ============
 
@@ -22,7 +27,6 @@ Version 18.0
     * Moved the existing ``heralding_mode`` parameter to :class:`CircuitCompilationOptions`.
     * Introduced new option ``move_gate_validation`` to turn off MOVE gate validation during compilation (ADVANCED).
     * Introduced new option ``move_gate_frame_tracking`` to turn off frame tracking for the MOVE gate (ADVANCED).
-
 
 Version 17.8
 ============

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -15,6 +15,10 @@ and install it in editable mode with all the extras:
    $ cd iqm-client
    $ pip install -e ".[dev,docs,testing]"
 
+(Unless you need the full commit history, consider using the ``--depth`` option for ``git clone``,
+for example ``--depth 1`` to only clone the latest commit. This will be much faster than cloning
+the full repository, because some large files have been stored in the commit history.)
+
 
 Build and view the docs:
 
@@ -22,10 +26,7 @@ Build and view the docs:
 
    $ tox -e docs
 
-To view the documentation, open the file ``build/sphinx/html/index.html``
-in a browser. Note that a separate version of documentation is built for each git tag.
-File ``build/sphinx/html/index.html`` simply redirects to the latest version of the
-documentation.
+To view the documentation, open the file ``build/sphinx/html/index.html`` in a browser.
 
 
 Run the tests:

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,12 @@ corresponding tag, and running the docs builder. For example, to build the docum
     $ git checkout 15.4
     $ tox run -e docs
 
-``tox run -e docs`` will build the documentation at ``./build/sphinx/html``. This command requires the ``tox,``, ``sphinx`` and 
+(Unless you need to build documentation for multiple versions, consider passing ``git clone`` options to
+only clone the commit for the specific version tag, e.g. ``--branch 15.4 --depth 1`` for version ``15.4``.
+This will be much faster than cloning the full repository, because some large files have been stored
+in the commit history.)
+
+``tox run -e docs`` will build the documentation at ``./build/sphinx/html``. This command requires the ``tox,``, ``sphinx`` and
 ``sphinx-book-theme`` Python packages (see the ``docs`` optional dependency in ``pyproject.toml``); 
 you can install the necessary packages with ``pip install -e ".[dev,docs]"``
 


### PR DESCRIPTION
Removes the files under `build/sphinx/html/.doctrees` when publishing the documentation to `gh-pages`. This helps reduce repository size growth, which was mainly due to the 4 MB `environment.pickle` file stored there.

Also updates documentation to suggest some `git clone` options which allow faster cloning by not including the full commit history.

**Testing**

I tested this on my personal `iqm-client` fork, you can see that the commit https://github.com/jkotilahti/iqm-client/commit/80a98e28fcdaade1bd8a2bd55e0ac2b077cc3e82 which does the modification to `publish.yml` results in `gh-pages` commit https://github.com/jkotilahti/iqm-client/commit/00f0d2001514181f349f847d75903aa124900612 which removes all files in `build/sphinx/html/.doctrees` from `gh-pages`. You can also check that any earlier `gh-pages` commits in either repo have files under that folder. The files in `.doctrees` are unnecessary for displaying the built documentation, you can see that the built documentation https://jkotilahti.github.io/iqm-client/ looks correct. (but it has some extra text from test commits, also the version is wrong because I removed other gitlab jobs except docs publishing there)

_(Further details: The `environment.pickle` file changed on every `gh-pages` commit, so even with any compression done by `git` that file has almost single-handedly been responsible for almost 500MB of repository size bloat based on my tests. The only way to significantly reduce the repository size would be to rewrite the commit history so that any references to that file are removed. However, it was decided to not rewrite commit history since it could cause many issues with a public repository like this. The next best thing to do was to prevent further unnecessary repository growth, which is done in this MR.)_