### PR TITLE
Do not check external token expiration.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 18.4
+============
+
+* Do not verify external auth token expiration. This fixes IQM Resonance authentication. `#134 <https://github.com/iqm-finland/iqm-client/pull/134>`_
+
 Version 18.3
 ============
 

--- a/src/iqm/iqm_client/authentication.py
+++ b/src/iqm/iqm_client/authentication.py
@@ -118,6 +118,7 @@ class TokenManager:
         if not auth_parameters:
             self._token_provider = None
         elif set(auth_parameters) == {'token'}:
+            # This is not necessary a JWT token
             self._token_provider = ExternalToken(auth_parameters['token'])
         elif set(auth_parameters) == {'tokens_file'}:
             self._token_provider = TokensFileReader(auth_parameters['tokens_file'])
@@ -204,8 +205,8 @@ class ExternalToken(TokenProviderInterface):
         self._token: Optional[str] = token
 
     def get_token(self) -> str:
-        if self._token is None or TokenManager.time_left_seconds(self._token) <= 0:
-            raise ClientAuthenticationError('External token has expired or is not valid')
+        if self._token is None:
+            raise ClientAuthenticationError('No external token available')
         return self._token
 
     def close(self) -> None:

--- a/src/iqm/iqm_client/authentication.py
+++ b/src/iqm/iqm_client/authentication.py
@@ -118,7 +118,7 @@ class TokenManager:
         if not auth_parameters:
             self._token_provider = None
         elif set(auth_parameters) == {'token'}:
-            # This is not necessary a JWT token
+            # This is not necessarily a JWT token
             self._token_provider = ExternalToken(auth_parameters['token'])
         elif set(auth_parameters) == {'tokens_file'}:
             self._token_provider = TokensFileReader(auth_parameters['tokens_file'])

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -76,7 +76,7 @@ def test_external_token_provides_token():
     assert provider.get_token() == token
     with pytest.raises(ClientAuthenticationError, match='Can not close externally managed auth session'):
         provider.close()
-    with pytest.raises(ClientAuthenticationError, match='External token has expired or is not valid'):
+    with pytest.raises(ClientAuthenticationError, match='No external token available'):
         provider.get_token()
 
     verifyNoUnwantedInteractions()


### PR DESCRIPTION
External token can be any kind of token, not necessary JWT, like, for example IQM Resonance token. No need to verify it's expiration as its lifecycle is managed externally.