### PR TITLE
Fix move gate validation for partial qubit mapping

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 18.7
+============
+
+* Fix MOVE gate validation for qubit mappings containing only some of the architecture qubits `#137 <https://github.com/iqm-finland/iqm-client/pull/137>`_
+
 Version 18.6
 ============
 

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -454,8 +454,8 @@ class IQMClient:
         all_qubits = set(architecture.qubits) - all_resonators
         if qubit_mapping:
             reverse_mapping = {phys: log for log, phys in qubit_mapping.items()}
-            all_resonators = {reverse_mapping[q] for q in all_resonators}
-            all_qubits = {reverse_mapping[q] for q in all_qubits}
+            all_resonators = {reverse_mapping[q] if q in reverse_mapping else q for q in all_resonators}
+            all_qubits = {reverse_mapping[q] if q in reverse_mapping else q for q in all_qubits}
 
         # Mapping from resonator to the qubit whose state it holds. Resonators not in the map hold no qubit state.
         resonator_occupations: dict[str, str] = {}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -311,3 +311,7 @@ class TestMoveValidation:
         cz = Instruction(name='cz', qubits=[reverse_qb_mapping[qb] for qb in ['QB2', 'COMP_R']], args={})
         TestMoveValidation.make_circuit_and_check((move, move), arch, validation_mode, sample_qb_mapping)
         TestMoveValidation.make_circuit_and_check((prx, move, cz, move), arch, validation_mode, sample_qb_mapping)
+        # qubit mapping without all qubits/resonators in the architecture
+        partial_qb_mapping = {k: v for k, v in sample_qb_mapping.items() if v in ['QB2', 'QB3', 'COMP_R']}
+        TestMoveValidation.make_circuit_and_check((move, move), arch, validation_mode, partial_qb_mapping)
+        TestMoveValidation.make_circuit_and_check((prx, move, cz, move), arch, validation_mode, partial_qb_mapping)


### PR DESCRIPTION
Some `qiskit-on-iqm` unit tests fail without this fix.