### PR TITLE
Add warnings when client version is not compatible with the server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 20.2
+============
+
+* Add warning when initializing client with server that has incompatible version. `#145 <https://github.com/iqm-finland/iqm-client/pull/145>`_
+* Improve error message when an endpoint returns a 404 error due to the server version not supporting the endpoint. `#145 <https://github.com/iqm-finland/iqm-client/pull/145>`_
+
 Version 20.1
 ============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 requires-python = ">=3.9, <3.12"
 dependencies = [
     "numpy",
+    "packaging",
     "requests >= 2.28.2, < 3.0",
     "pydantic >= 2.4.2, < 3.0",
 ]

--- a/src/iqm/iqm_client/api.py
+++ b/src/iqm/iqm_client/api.py
@@ -34,6 +34,7 @@ class APIEndpoint(Enum):
     DELETE_JOB = auto()
     HEALTH = auto()
     ABOUT = auto()
+    CLIENT_LIBRARIES = auto()
 
     # Calibration and Calibration Service endpoints
     CALIBRATION_SERVICE_CONFIGURATION = auto()
@@ -97,6 +98,7 @@ class APIConfig:
                 APIEndpoint.QUALITYT_METRICS_MONITORING: "api/v1/monitor/calibration/metrics",
                 APIEndpoint.HEALTH: "health",
                 APIEndpoint.ABOUT: "about",
+                APIEndpoint.CLIENT_LIBRARIES: "info/client-libraries",
                 APIEndpoint.START_CALIBRATION_JOB: "calibration/run",
                 APIEndpoint.CALIBRATION_SERVICE_CONFIGURATION: "calibration/configuration",
                 APIEndpoint.CALIBRATION_SERVICE_JOBS: "calibration/jobs",
@@ -123,6 +125,7 @@ class APIConfig:
                 APIEndpoint.QUALITYT_METRICS_MONITORING: "cocos/api/v1/monitor/calibration/metrics",
                 APIEndpoint.HEALTH: "cocos/health",
                 APIEndpoint.ABOUT: "cocos/about",
+                APIEndpoint.CLIENT_LIBRARIES: "info/client-libraries",
                 APIEndpoint.START_CALIBRATION_JOB: "cocos/calibration/run",
                 APIEndpoint.CALIBRATION_SERVICE_CONFIGURATION: "cocos/calibration/configuration",
                 APIEndpoint.CALIBRATION_SERVICE_JOBS: "cocos/calibration/jobs",

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -942,8 +942,8 @@ class IQMClient:
             client_version = parse(version('iqm-client'))
             if client_version < min_version or client_version >= max_version:
                 return (
-                    f'IQM Client version {client_version} is incompatible with the IQM server, '
-                    f'which requires {min_version} <= iqm-client < {max_version}. '
-                    f'Please use a compatible client version to make sure all features work correctly.'
+                    f'Your IQM Client version {client_version} was built for a different version of IQM Server. '
+                    f'You might encounter issues. For the best experience, consider using a version '
+                    f'of IQM Client that satisfies {min_version} <= iqm-client < {max_version}.'
                 )
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -544,6 +544,7 @@ class MockJsonResponse:
         self.status_code = status_code
         self.json_data = json_data
         self.history = history
+        self.url = 'https://example.com'
 
     @property
     def text(self):

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -1031,8 +1031,9 @@ def test_get_dynamic_quantum_architecture_not_found(base_url, sample_client):
     with pytest.raises(
         HTTPError,
         match=re.escape(
-            f'IQM Client version {client_version} is incompatible with the IQM server, '
-            f'which requires {min_version} <= iqm-client < {max_version}'
+            f'Your IQM Client version {client_version} was built for a different version of IQM Server. '
+            f'You might encounter issues. For the best experience, consider using a version '
+            f'of IQM Client that satisfies {min_version} <= iqm-client < {max_version}.'
         ),
     ):
         sample_client.get_dynamic_quantum_architecture()
@@ -1063,8 +1064,9 @@ def test_check_versions(base_url, server_version_diff, recwarn):
         with pytest.warns(
             UserWarning,
             match=re.escape(
-                f'IQM Client version {client_version} is incompatible with the IQM server, '
-                f'which requires {min_version} <= iqm-client < {max_version}'
+                f'Your IQM Client version {client_version} was built for a different version of IQM Server. '
+                f'You might encounter issues. For the best experience, consider using a version '
+                f'of IQM Client that satisfies {min_version} <= iqm-client < {max_version}.'
             ),
         ):
             IQMClient(base_url)

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -1014,8 +1014,8 @@ def test_get_dynamic_quantum_architecture_throws_json_decode_error_if_received_n
 def test_get_dynamic_quantum_architecture_not_found(base_url, sample_client):
     """Test that an informative error message is returned when 404 is returned due to version incompatibility."""
     client_version = parse(version('iqm-client'))
-    min_version = f'{client_version.major - 2}.0'
-    max_version = f'{client_version.major - 1}.0'
+    min_version = f'{client_version.major + 2}.0'
+    max_version = f'{client_version.major + 3}.0'
     when(requests).get(f'{base_url}/info/client-libraries', headers=ANY, timeout=ANY).thenReturn(
         MockJsonResponse(
             200,
@@ -1036,9 +1036,10 @@ def test_get_dynamic_quantum_architecture_not_found(base_url, sample_client):
         ),
     ):
         sample_client.get_dynamic_quantum_architecture()
+    unstub()
 
 
-@pytest.mark.parametrize('server_version_diff', [-1, 0, 1])
+@pytest.mark.parametrize('server_version_diff', [0, 1])
 def test_check_versions(base_url, server_version_diff, recwarn):
     """Test that a warning about version incompatibility is shown when initializing client with incompatible server."""
     client_version = parse(version('iqm-client'))
@@ -1067,3 +1068,4 @@ def test_check_versions(base_url, server_version_diff, recwarn):
             ),
         ):
             IQMClient(base_url)
+    unstub()


### PR DESCRIPTION
* The first commit adds a warning when initializing IQMClient connected to a server for which the reported compatible iqm-client version range (from `/info/client-libraries`) does not include the current version. The warning does not prevent using the client, since it is still possible that things work even if the version is officially incompatible. Example of how the warning looks like:

    `UserWarning: Your IQM Client version 21.0 was built for a different version of IQM Server. You might encounter issues. For the best experience, consider using a version of IQM Client that satisfies 20.0 <= iqm-client < 21.0.`

* The second commit improves the error message when an endpoint returns 404 and the client version is incompatible with the server. This can happen if an endpoint used by the current client version is removed in a new server version, or if the current client version adds support for using an endpoint that is not yet supported by the server (like happened in https://github.com/iqm-finland/qiskit-on-iqm/issues/121). Previously, it was not clear to users from the error message that the 404 was caused by version incompatibility, but now it would show for example this message:

    `requests.exceptions.HTTPError: https://test.qc.iqm.fi/cocos/api/v1/calibration/default/gates not found. This may be caused by the server version not supporting this endpoint. Your IQM Client version 21.0 was built for a different version of IQM Server. You might encounter issues. For the best experience, consider using a version of IQM Client that satisfies 18.0 <= iqm-client < 19.0.`

    For some endpoints, there was already special handling for 404 errors (for example it can mean a job with a specific id was not found), so for those ones I did not add this change.