### PR TITLE
Fixed client version compatibility check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 20.5
 ============
 
-* Fixed client version compatibility check.
+* Fixed client version compatibility check. `#148 <https://github.com/iqm-finland/iqm-client/pull/148>`_
 
 Version 20.4
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 20.5
+============
+
+* Fixed client version compatibility check.
+
 Version 20.4
 ============
 * ``active_reset_cycles`` added to ``CircuitCompilationOptions`` (in 20.2 it was only added to ``RunRequest`` making it

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -936,14 +936,21 @@ class IQMClient:
             timeout=REQUESTS_TIMEOUT,
         )
         if versions_response.status_code == 200:
-            compatible_versions = versions_response.json()['iqm-client']
-            min_version = parse(compatible_versions['min'])
-            max_version = parse(compatible_versions['max'])
-            client_version = parse(version('iqm-client'))
-            if client_version < min_version or client_version >= max_version:
+            try:
+                libraries = versions_response.json()
+                compatible_versions = libraries.get('iqm_client', libraries.get('iqm-client'))
+                min_version = parse(compatible_versions['min'])
+                max_version = parse(compatible_versions['max'])
+                client_version = parse(version('iqm-client'))
+                if client_version < min_version or client_version >= max_version:
+                    return (
+                        f'Your IQM Client version {client_version} was built for a different version of IQM Server. '
+                        f'You might encounter issues. For the best experience, consider using a version '
+                        f'of IQM Client that satisfies {min_version} <= iqm-client < {max_version}.'
+                    )
+            except Exception: # pylint: disable=broad-except
                 return (
-                    f'Your IQM Client version {client_version} was built for a different version of IQM Server. '
-                    f'You might encounter issues. For the best experience, consider using a version '
-                    f'of IQM Client that satisfies {min_version} <= iqm-client < {max_version}.'
+                    f'Could not verify IQM client library compatibility. You might encounter issues.'
                 )
+
         return None

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -948,9 +948,7 @@ class IQMClient:
                         f'You might encounter issues. For the best experience, consider using a version '
                         f'of IQM Client that satisfies {min_version} <= iqm-client < {max_version}.'
                     )
-            except Exception: # pylint: disable=broad-except
-                return (
-                    f'Could not verify IQM client library compatibility. You might encounter issues.'
-                )
+            except Exception:  # pylint: disable=broad-except
+                return f'Could not verify IQM client library compatibility. You might encounter issues.'
 
         return None

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -938,7 +938,7 @@ class IQMClient:
         if versions_response.status_code == 200:
             try:
                 libraries = versions_response.json()
-                compatible_versions = libraries.get('iqm_client', libraries.get('iqm-client'))
+                compatible_versions = libraries.get('iqm-client', libraries.get('iqm_client'))
                 min_version = parse(compatible_versions['min'])
                 max_version = parse(compatible_versions['max'])
                 client_version = parse(version('iqm-client'))
@@ -949,6 +949,6 @@ class IQMClient:
                         f'of IQM Client that satisfies {min_version} <= iqm-client < {max_version}.'
                     )
             except Exception:  # pylint: disable=broad-except
-                return f'Could not verify IQM client library compatibility. You might encounter issues.'
+                return 'Could not verify IQM client library compatibility. You might encounter issues.'
 
         return None

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -1073,21 +1073,18 @@ def test_check_versions_success(base_url, server_version_diff, recwarn):
             IQMClient(base_url)
     unstub()
 
+
 def test_check_versions_bad_response(base_url):
     """Test that unexpected response from /client-libraries endpoint does not break the client."""
     when(requests).get(f'{base_url}/info/client-libraries', headers=ANY, timeout=ANY).thenReturn(
         MockJsonResponse(
             200,
-            {
-                'iqm_client': 'invalid-payload'
-            },
+            {'iqm_client': 'invalid-payload'},
         )
     )
     with pytest.warns(
-            UserWarning,
-            match=re.escape(
-                f'Could not verify IQM client library compatibility. You might encounter issues.'
-            ),
+        UserWarning,
+        match=re.escape(f'Could not verify IQM client library compatibility. You might encounter issues.'),
     ):
         IQMClient(base_url)
     unstub()

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -1090,7 +1090,7 @@ def test_check_versions_bad_response(base_url):
     )
     with pytest.warns(
         UserWarning,
-        match=re.escape(f'Could not verify IQM client library compatibility. You might encounter issues.'),
+        match=re.escape('Could not verify IQM client library compatibility. You might encounter issues.'),
     ):
         IQMClient(base_url)
     unstub()

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -1041,8 +1041,14 @@ def test_get_dynamic_quantum_architecture_not_found(base_url, sample_client):
     unstub()
 
 
-@pytest.mark.parametrize('server_version_diff', [0, 1])
-def test_check_versions_success(base_url, server_version_diff, recwarn):
+@pytest.mark.parametrize(
+    'iqm_client_name,server_version_diff',
+    [
+        ('iqm_client', 0),
+        ('iqm-client', 1),
+    ],
+)
+def test_check_versions_success(base_url, iqm_client_name, server_version_diff, recwarn):
     """Test that a warning about version incompatibility is shown when initializing client with incompatible server."""
     client_version = parse(version('iqm-client'))
     min_version = f'{client_version.major + server_version_diff}.0'
@@ -1051,7 +1057,7 @@ def test_check_versions_success(base_url, server_version_diff, recwarn):
         MockJsonResponse(
             200,
             {
-                'iqm_client': {
+                iqm_client_name: {
                     'min': min_version,
                     'max': max_version,
                 }


### PR DESCRIPTION
In the previous PR https://github.com/iqm-finland/iqm-client/pull/145 a compatibility check expected dict key `iqm-client`, while actually `iqm_client` was returned from server, breaking client code.

This PR fixes the expected dict key and also ensures any other errors during compatibility check do not break the client completely.