### PR TITLE
Improve version compatibility check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 20.6
+============
+
+* Improve version compatibility check to avoid it preventing usage of the client in any situation. `#150 <https://github.com/iqm-finland/iqm-client/pull/150>`_
+
 Version 20.5
 ============
 

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -927,16 +927,16 @@ class IQMClient:
         """Checks the client version against compatible client versions reported by server.
 
         Returns:
-            A message about the versions being incompatible if they are,
-            None if they are compatible or if the version information could not be obtained.
+            A message about client incompatibility with the server if the versions are incompatible or if the
+            compatibility could not be confirmed, None if they are compatible.
         """
-        versions_response = requests.get(
-            self._api.url(APIEndpoint.CLIENT_LIBRARIES),
-            headers=self._default_headers(),
-            timeout=REQUESTS_TIMEOUT,
-        )
-        if versions_response.status_code == 200:
-            try:
+        try:
+            versions_response = requests.get(
+                self._api.url(APIEndpoint.CLIENT_LIBRARIES),
+                headers=self._default_headers(),
+                timeout=REQUESTS_TIMEOUT,
+            )
+            if versions_response.status_code == 200:
                 libraries = versions_response.json()
                 compatible_versions = libraries.get('iqm-client', libraries.get('iqm_client'))
                 min_version = parse(compatible_versions['min'])
@@ -948,7 +948,8 @@ class IQMClient:
                         f'You might encounter issues. For the best experience, consider using a version '
                         f'of IQM Client that satisfies {min_version} <= iqm-client < {max_version}.'
                     )
-            except Exception:  # pylint: disable=broad-except
-                return 'Could not verify IQM client library compatibility. You might encounter issues.'
-
-        return None
+                return None
+        except Exception:  # pylint: disable=broad-except
+            # we don't want the version check to prevent usage of IQMClient in any situation
+            pass
+        return 'Could not verify IQM Client compatibility with the server. You might encounter issues.'

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -1090,7 +1090,20 @@ def test_check_versions_bad_response(base_url):
     )
     with pytest.warns(
         UserWarning,
-        match=re.escape('Could not verify IQM client library compatibility. You might encounter issues.'),
+        match=re.escape('Could not verify IQM Client compatibility with the server. You might encounter issues.'),
+    ):
+        IQMClient(base_url)
+    unstub()
+
+
+def test_check_versions_request_exception(base_url):
+    """Test that exception raised by request to /client-libraries endpoint does not break the client."""
+    when(requests).get(f'{base_url}/info/client-libraries', headers=ANY, timeout=ANY).thenRaise(
+        requests.exceptions.RequestException
+    )
+    with pytest.warns(
+        UserWarning,
+        match=re.escape('Could not verify IQM Client compatibility with the server. You might encounter issues.'),
     ):
         IQMClient(base_url)
     unstub()


### PR DESCRIPTION
The version compatibility check added in https://github.com/iqm-finland/iqm-client/pull/145 could in some cases raise an exception when initializing IQMClient, preventing usage of IQMClient. This should not happen, because the version check was only meant as an informative warning, never totally preventing usage. Some cases where this could happen were fixed in https://github.com/iqm-finland/iqm-client/pull/148, but there still remained the possibility that `versions_response = requests.get(...)` would raise an exception, leading to the same problem. 

This PR prevents the version check from ever raising exceptions, so that it never prevents the usage of IQMClient. Also some other small adjustments are made to the incompatibility messages and when they are returned.