### PR TITLE
Less strict versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+
+Version 20.15
+=============
+
+* Relax version ranges of `numpy`, `packaging`. `#165 <https://github.com/iqm-finland/iqm-client/pull/165>`_
+
 Version 20.14
 =============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 ]
 requires-python = ">=3.10, <3.13"
 dependencies = [
-    "numpy >= 2.2.1, < 3.0",
-    "packaging >= 24.2, < 25.0",
+    "numpy < 3.0",
+    "packaging >= 24.1, < 25.0",
     "requests >= 2.28.2, < 3.0",
     "pydantic >= 2.4.2, < 3.0",
 ]


### PR DESCRIPTION
* Relax version range of numpy. https://github.com/iqm-finland/iqm-client/issues/164
* Relax version range of packaging, causes issues with other repos.