### PR TITLE
Fix DQA deserialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 20.17
+=============
+
+* Fix DQA deserialization when ``override_default_implementations`` has keys containing more than one locus component. `#166 <https://github.com/iqm-finland/iqm-client/pull/166>`_
+
 Version 20.16
 =============
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 20.17
 =============
 
-* Fix DQA deserialization when ``override_default_implementations`` has keys containing more than one locus component. `#166 <https://github.com/iqm-finland/iqm-client/pull/166>`_
+* Fix DQA deserialization when ``override_default_implementations`` is not empty. `#166 <https://github.com/iqm-finland/iqm-client/pull/166>`_
 
 Version 20.16
 =============

--- a/src/iqm/iqm_client/models.py
+++ b/src/iqm/iqm_client/models.py
@@ -550,6 +550,26 @@ class GateInfo(BaseModel):
     override_default_implementation: dict[Locus, str] = Field(...)
     """mapping of loci to implementation names that override ``default_implementation`` for those loci"""
 
+    @field_validator('override_default_implementation', mode='before')
+    @classmethod
+    def override_default_implementation_validator(cls, value: Any) -> dict[Locus, str]:
+        """Converts locus keys to tuples if they are encoded as strings."""
+        new_value = {}
+        if isinstance(value, dict):
+            for k, v in value.items():
+                if isinstance(k, tuple):
+                    new_value[k] = v
+                # When Pydantic serializes a dict with tuple keys into JSON, the keys are turned into
+                # comma-separated strings (because JSON only supports string keys). Here we convert
+                # them back into tuples.
+                elif isinstance(k, str):
+                    new_k = tuple(k.split(','))
+                    new_value[new_k] = v
+                else:
+                    raise ValueError("'override_default_implementation' keys must be strings or tuples.")
+            return new_value
+        raise ValueError("'override_default_implementation' must be a dict.")
+
     @cached_property
     def loci(self) -> tuple[Locus, ...]:
         """Returns all loci which are available for at least one of the implementations.

--- a/tests/test_iqm_client.py
+++ b/tests/test_iqm_client.py
@@ -33,9 +33,9 @@ from iqm.iqm_client import (
     CircuitExecutionError,
     CircuitValidationError,
     ClientConfigurationError,
+    Counts,
     DDMode,
     DDStrategy,
-    Counts,
     DynamicQuantumArchitecture,
     HeraldingMode,
     Instruction,
@@ -638,15 +638,12 @@ def test_get_quantum_architecture(
     unstub()
 
 
-def test_get_feedback_groups(
-    base_url, channel_properties_url, channel_properties_success, static_architecture_success
-):
+def test_get_feedback_groups(base_url, channel_properties_url, channel_properties_success, static_architecture_success):
     """Test retrieving the feedback groups."""
     when(requests).get(f'{base_url}/info/client-libraries', headers=ANY, timeout=ANY).thenReturn(
         mock_supported_client_libraries_response()
     )
-    expect(requests, times=1).get(f'{base_url}/cocos/quantum-architecture', ...).thenReturn(
-        static_architecture_success)
+    expect(requests, times=1).get(f'{base_url}/cocos/quantum-architecture', ...).thenReturn(static_architecture_success)
     iqm_client = IQMClient(base_url, api_variant=APIVariant.V2)
     expect(requests, times=1).get(channel_properties_url, ...).thenReturn(channel_properties_success)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the IQM client models."""
+import json
 from uuid import UUID
 
 import pytest
@@ -106,3 +107,28 @@ def test_dqa_components():
         gates={},
     )
     assert dqa.components == ('COMPR1', 'COMPR2', 'QB1', 'QB2', 'QB3', 'QB10', 'QB11', 'QB20')
+
+
+def test_dqa_deserialization():
+    dqa = DynamicQuantumArchitecture(
+        calibration_set_id=UUID('59478539-dcef-4b2e-80c8-122d7ec3fc89'),
+        qubits=['QB1', 'QB2'],
+        computational_resonators=['COMP_R'],
+        gates={
+            'cz': GateInfo(
+                implementations={
+                    'tgss': GateImplementationInfo(
+                        loci=(('QB1', 'QB2'), ('QB1', 'COMP_R')),
+                    ),
+                    'crf': GateImplementationInfo(loci=(('QB2', 'COMPR'),)),
+                },
+                default_implementation='tgss',
+                override_default_implementation={('QB2', 'COMPR'): 'crf'},
+            ),
+        },
+    )
+
+    dqa_json = dqa.model_dump_json()
+    dqa_reconstructed = DynamicQuantumArchitecture(**json.loads(dqa_json))
+
+    assert dqa_reconstructed == dqa


### PR DESCRIPTION
When Pydantic serializes a dict with tuple keys into JSON, the keys are turned into comma-separated strings (because JSON only supports string keys). That can happen for DQA if `GateInfo.override_default_implementation` has keys with multiple locus components. For example, `("QB2", "COMPR1")` key in Python becomes `"QB2,COMPR1"` in the JSON. But apparently Pydantic cannot automatically deserialize it back into the original format properly. 

This PR adds a [before field validator](https://docs.pydantic.dev/latest/concepts/validators/#field-validators) which converts such comma-separated strings back into tuples of strings. Also added a unit test which fails without this fix.